### PR TITLE
Fix macro targets table reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -1394,7 +1394,7 @@ function saveSliderMacros() {
       Fat:      f,
       Carbs:    c
     };
-    airtableSave(macroTargetsTableName, fields)
+    airtableSave(MacroTargetsTableName, fields)
       .then(id => {
         if (id) {
           showToast("Macro targets saved!");


### PR DESCRIPTION
## Summary
- fix variable name in `saveSliderMacros`
- ensure MacroTargets table name is used consistently

## Testing
- `node - <<'NODE'` snippet to confirm constant usage
- `node - <<'NODE'` snippet to simulate saving macros

------
https://chatgpt.com/codex/tasks/task_e_683f860a46a083239e098b3742f02a0d