### PR TITLE
Fix DOMContentLoaded comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -1845,7 +1845,7 @@ function removeCrossfitExercise(index) {
   
   document.addEventListener("DOMContentLoaded", () => {
 
-    // Add your showTab function first
+    // showTab is defined above
 
 // === Airtable Functions ===
 
@@ -2099,7 +2099,7 @@ if (savedUser) {
   renderWeights();
   renderCardio();
   renderCrossfitWorkouts();
-  loadTemplateDropdown(); // ✅ Needed here too
+  loadTemplateDropdown();
 }
 
 
@@ -2184,8 +2184,6 @@ window.addEventListener("DOMContentLoaded", () => {
   // Show the first tab initially
   showTab("logTab");
 
-  // Attach your other event listeners here as needed
-  // e.g. document.getElementById("btnAddLog").addEventListener("click", addLogEntry);
 
 
 


### PR DESCRIPTION
## Summary
- clarify that `showTab` is already defined
- clean up old instructional comments inside the `DOMContentLoaded` handler

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f8608a1388323b3d422db66ac929b