### PR TITLE
Fix macro progress resetting

### DIFF
--- a/index.html
+++ b/index.html
@@ -457,6 +457,7 @@ async function startLogin() {
       renderCardio();
       renderCrossfitWorkouts();
       loadTemplateDropdown(); // ✅ Load saved templates
+      saveDailyMacroProgress(0, 0, 0); // reset progress on login
       renderDailyMacroProgress();
     } else {
       alert(result.message || "Login failed.");
@@ -1575,7 +1576,7 @@ function updateDailyMacroProgress(protein, carbs, fats) {
 }
 
 function loadAndRenderDailyProgress() {
-  const progress = JSON.parse(localStorage.getItem("dailyMacroProgress")) || { protein: 0, carbs: 0, fats: 0 };
+  const progress = loadDailyMacroProgress();
   // Update macroMeals to match progress so your app state is consistent
   macroMeals = [{ protein: progress.protein, carbs: progress.carbs, fats: progress.fats }];
 
@@ -2247,22 +2248,6 @@ function closeMacroSettings() {
   // Restore the settings button visibility
   const btn = document.getElementById('macrosSettingsBtn');
   if (btn) btn.style.display = 'block';
-}
-
-// expose helpers for inline handlers
-window.openMacroSettings = openMacroSettings;
-window.closeMacroSettings = closeMacroSettings;
-
-function openMacroSettings() {
-  document.getElementById('macrosMainContent').style.display = 'none';
-  document.getElementById('macrosSettingsContent').style.display = 'block';
-
-}
-
-function closeMacroSettings() {
-  document.getElementById('macrosSettingsContent').style.display = 'none';
-  document.getElementById('macrosMainContent').style.display = 'block';
-
 }
 
 // expose helpers for inline handlers


### PR DESCRIPTION
## Summary
- reset stored macro progress on login so bars start empty
- load saved progress via helper to ensure date reset

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7291de588323ac74077ca2ac72a7