### PR TITLE
Fix workout history view

### DIFF
--- a/index.html
+++ b/index.html
@@ -999,6 +999,7 @@ function completeWorkout() {
   workouts.push({ title: `Workout on ${date}`, date, log: [] });
   localStorage.setItem(`workouts_${currentUser}`, JSON.stringify(workouts));
   renderWorkouts();
+  renderWorkoutHistory();
 }
 
 async function saveWorkoutToBackend(workout) {
@@ -1770,6 +1771,38 @@ function removeWorkout(index) {
   }
 }
 
+function renderWorkoutHistory() {
+  const container = document.getElementById("logHistoryContainer");
+  container.innerHTML = "";
+
+  const workouts = JSON.parse(localStorage.getItem(`workouts_${currentUser}`)) || [];
+  workouts
+    .filter(w => w.log && w.log.length > 0)
+    .slice()
+    .reverse()
+    .forEach(workout => {
+      const div = document.createElement("div");
+      div.style.border = "1px solid #ccc";
+      div.style.padding = "10px";
+      div.style.marginTop = "10px";
+
+      const exercisesHtml = workout.log
+        .map(entry => {
+          const sets = entry.repsArray
+            .map((rep, i) => `${rep} x ${entry.weightsArray[i] ?? '-'} ${entry.unit || 'kg'}`)
+            .join(', ');
+          return `${entry.exercise}: ${sets}`;
+        })
+        .join('<br>');
+
+      const volume = calculateWorkoutVolume(workout);
+      const unit = workout.log[0]?.unit || 'kg';
+
+      div.innerHTML = `<strong>${workout.title}</strong><br>${exercisesHtml}<br>Total Volume: ${volume} ${unit}`;
+      container.appendChild(div);
+    });
+}
+
 function addWeightEntry() {
   const weight = +document.getElementById("currentWeightInput").value;
   const date = new Date().toISOString().split('T')[0];
@@ -1874,9 +1907,48 @@ function removeCrossfitExercise(index) {
   const exerciseDiv = document.getElementById(`cfExerciseName${index}`).parentNode;
   exerciseDiv.remove();
   crossfitExercises = crossfitExercises.filter(i => i !== index);
-}  
+}
 
-  
+function addMacroHistoryEntry(date, meals, totals) {
+  const key = `macroHistory_${currentUser}`;
+  const history = JSON.parse(localStorage.getItem(key)) || [];
+  history.push({ date, meals, totals });
+  localStorage.setItem(key, JSON.stringify(history));
+}
+
+function renderMacroHistory() {
+  const key = `macroHistory_${currentUser}`;
+  const history = JSON.parse(localStorage.getItem(key)) || [];
+  const container = document.getElementById("macroHistoryContainer");
+  container.innerHTML = "";
+  history.slice().reverse().forEach(entry => {
+    const div = document.createElement("div");
+    const mealsHtml = entry.meals.map((m, i) => `Meal ${i + 1}: P${m.protein}, C${m.carbs}, F${m.fats}`).join("<br>");
+    const totals = entry.totals || { protein:0, carbs:0, fats:0 };
+    const cals = totals.protein * 4 + totals.carbs * 4 + totals.fats * 9;
+    div.innerHTML = `<strong>${entry.date}</strong><br>${mealsHtml}<br>Total: ${cals} kcal`;
+    container.appendChild(div);
+  });
+}
+
+function showHistoryMiniTab(tab) {
+  const workoutTab = document.getElementById("workoutHistoryMiniTab");
+  const macroTab = document.getElementById("macroHistoryMiniTab");
+  if (tab === "macro") {
+    workoutTab.style.display = "none";
+    macroTab.style.display = "block";
+    renderMacroHistory();
+  } else {
+    macroTab.style.display = "none";
+    workoutTab.style.display = "block";
+    renderWorkoutHistory();
+  }
+}
+
+
+
+
+
   document.addEventListener("DOMContentLoaded", () => {
 
     // initial setup for macros
@@ -1970,40 +2042,6 @@ function renderLogHistory(logs) {
   }
 }
 
-function addMacroHistoryEntry(date, meals, totals) {
-  const key = `macroHistory_${currentUser}`;
-  const history = JSON.parse(localStorage.getItem(key)) || [];
-  history.push({ date, meals, totals });
-  localStorage.setItem(key, JSON.stringify(history));
-}
-
-function renderMacroHistory() {
-  const key = `macroHistory_${currentUser}`;
-  const history = JSON.parse(localStorage.getItem(key)) || [];
-  const container = document.getElementById("macroHistoryContainer");
-  container.innerHTML = "";
-  history.slice().reverse().forEach(entry => {
-    const div = document.createElement("div");
-    const mealsHtml = entry.meals.map((m, i) => `Meal ${i + 1}: P${m.protein}, C${m.carbs}, F${m.fats}`).join("<br>");
-    const totals = entry.totals || { protein:0, carbs:0, fats:0 };
-    const cals = totals.protein * 4 + totals.carbs * 4 + totals.fats * 9;
-    div.innerHTML = `<strong>${entry.date}</strong><br>${mealsHtml}<br>Total: ${cals} kcal`;
-    container.appendChild(div);
-  });
-}
-
-function showHistoryMiniTab(tab) {
-  const workoutTab = document.getElementById("workoutHistoryMiniTab");
-  const macroTab = document.getElementById("macroHistoryMiniTab");
-  if (tab === "macro") {
-    workoutTab.style.display = "none";
-    macroTab.style.display = "block";
-    renderMacroHistory();
-  } else {
-    macroTab.style.display = "none";
-    workoutTab.style.display = "block";
-  }
-}
 
     
 
@@ -2283,6 +2321,7 @@ window.removeLogEntry = removeLogEntry;             // ✅ Add this
   window.saveWorkoutAsTemplate = saveWorkoutAsTemplate;
   window.loadTemplateDropdown = loadTemplateDropdown;
   window.showHistoryMiniTab = showHistoryMiniTab;
+  window.renderWorkoutHistory = renderWorkoutHistory;
 function openMacroSettings() {
   // Hide the main macros content and reveal the settings view
   document.getElementById('macrosMainContent').style.display = 'none';


### PR DESCRIPTION
## Summary
- update **showHistoryMiniTab** to render workouts
- implement **renderWorkoutHistory** for the log history tab
- keep workout history up to date when completing a workout
- expose `renderWorkoutHistory` globally

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408d0514fc832394cbab80ea170c26