### PR TITLE
Auto-archive old workouts

### DIFF
--- a/archiveOldWorkouts.js
+++ b/archiveOldWorkouts.js
@@ -1,0 +1,32 @@
+function archiveOldWorkouts(currentUser, now = Date.now()) {
+  if (!currentUser) return;
+  const workoutsKey = `workouts_${currentUser}`;
+  const historyKey = `workoutHistory_${currentUser}`;
+
+  const workouts = JSON.parse(localStorage.getItem(workoutsKey)) || [];
+  const history = JSON.parse(localStorage.getItem(historyKey)) || [];
+  const sevenDays = 7 * 24 * 60 * 60 * 1000;
+
+  const recent = [];
+  workouts.forEach(w => {
+    const wDate = new Date(w.date);
+    const isOld = w.log && w.log.length > 0 && !isNaN(wDate) && (now - wDate.getTime() > sevenDays);
+    if (isOld) {
+      history.push(w);
+    } else {
+      recent.push(w);
+    }
+  });
+
+  if (recent.length !== workouts.length) {
+    localStorage.setItem(workoutsKey, JSON.stringify(recent));
+    localStorage.setItem(historyKey, JSON.stringify(history));
+  }
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { archiveOldWorkouts };
+}
+if (typeof window !== 'undefined') {
+  window.archiveOldWorkouts = archiveOldWorkouts;
+}

--- a/index.html
+++ b/index.html
@@ -387,7 +387,8 @@
 
   
 </div>
-  
+
+<script src="archiveOldWorkouts.js"></script>
 <script>
 
   
@@ -734,6 +735,7 @@ function addLogEntry() {
 
   
 function renderWorkouts() {
+  archiveOldWorkouts(currentUser);
   const workouts = JSON.parse(localStorage.getItem(`workouts_${currentUser}`)) || [];
   const container = document.getElementById("workoutsContainer");
 
@@ -819,6 +821,8 @@ function renderWorkouts() {
     const el = document.getElementById(`workoutDetails${index}`);
     if (el) el.style.display = 'block';
   });
+
+  renderWorkoutHistory();
 
   window.renderWorkouts = renderWorkouts;
   window.toggleWorkoutDetails = toggleWorkoutDetails;
@@ -1776,10 +1780,11 @@ function renderWorkoutHistory() {
   container.innerHTML = "";
 
   const workouts = JSON.parse(localStorage.getItem(`workouts_${currentUser}`)) || [];
-  workouts
-    .filter(w => w.log && w.log.length > 0)
+  const history = JSON.parse(localStorage.getItem(`workoutHistory_${currentUser}`)) || [];
+  const all = history.concat(workouts.filter(w => w.log && w.log.length > 0));
+  all
     .slice()
-    .reverse()
+    .sort((a, b) => new Date(b.date) - new Date(a.date))
     .forEach(workout => {
       const div = document.createElement("div");
       div.style.border = "1px solid #ccc";

--- a/tests/archiveOldWorkouts.test.js
+++ b/tests/archiveOldWorkouts.test.js
@@ -1,0 +1,35 @@
+const { archiveOldWorkouts } = require('../archiveOldWorkouts');
+
+describe('archiveOldWorkouts', () => {
+  beforeEach(() => {
+    global.localStorage = {
+      store: {},
+      getItem(key) { return this.store[key] || null; },
+      setItem(key, val) { this.store[key] = String(val); },
+      clear() { this.store = {}; }
+    };
+  });
+
+  test('moves workouts older than 7 days to history', () => {
+    const user = 'u1';
+    const workoutsKey = `workouts_${user}`;
+    const historyKey = `workoutHistory_${user}`;
+    const oldDate = new Date(Date.now() - 8 * 86400000).toISOString().split('T')[0];
+    const recentDate = new Date().toISOString().split('T')[0];
+    const workouts = [
+      { title: 'Old', date: oldDate, log: [{}] },
+      { title: 'Recent', date: recentDate, log: [{}] }
+    ];
+    localStorage.setItem(workoutsKey, JSON.stringify(workouts));
+
+    archiveOldWorkouts(user, Date.now());
+
+    const remaining = JSON.parse(localStorage.getItem(workoutsKey));
+    const history = JSON.parse(localStorage.getItem(historyKey));
+
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].title).toBe('Recent');
+    expect(history).toHaveLength(1);
+    expect(history[0].title).toBe('Old');
+  });
+});


### PR DESCRIPTION
## Summary
- archive workouts older than one week
- load archive file in the HTML
- show archived workouts in the history view
- add unit tests for archiving logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a274de608323ab7bbd1330bd724b