### PR TITLE
Move heading into sidebar menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,6 +86,14 @@
       left: 0;
     }
 
+    .menu-title {
+      font-size: 20px;
+      font-weight: bold;
+      padding: 10px 20px;
+      border-bottom: 1px solid var(--border-color);
+      text-align: center;
+    }
+
     .side-menu ul {
   list-style: none; /* removes the bullets */
   padding: 20px;
@@ -188,13 +196,12 @@
 
 <div id="appContainer" style="display:none;">
   
-  <h1>Fitness Tracker (<span id="userDisplay"></span>)</h1>
-
   <!-- Hamburger button -->
   <button id="menuToggle" class="menu-toggle">☰</button>
 
   <!-- Sidebar -->
   <nav id="sideMenu" class="side-menu">
+    <div class="menu-title">Fitness Tracker (<span id="userDisplay"></span>)</div>
     <ul>
       <li><a href="#" data-tab="logTab">Training Log</a></li>
       <li><a href="#" data-tab="weightTab">Bodyweight</a></li>


### PR DESCRIPTION
## Summary
- show the **Fitness Tracker** title inside the hamburger sidebar instead of above every tab

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a57d5ad08323acbefcb9e7d5ed3a