### PR TITLE
Add progressive overload suggestion helper

### DIFF
--- a/index.html
+++ b/index.html
@@ -405,6 +405,7 @@
 </div>
 
 <script src="archiveOldWorkouts.js"></script>
+<script src="progressiveOverload.js"></script>
 <script>
 
   
@@ -717,6 +718,8 @@ function addLogEntry() {
   if (!name) return;
 
   const last = getLastExerciseEntry(name);
+  const workouts = JSON.parse(localStorage.getItem(`workouts_${currentUser}`)) || [];
+  const suggestion = getProgressiveOverloadSuggestion(name, workouts);
   const msgDiv = document.getElementById("progressReminder");
   msgDiv.innerHTML = '';
 
@@ -726,7 +729,7 @@ function addLogEntry() {
     msgDiv.innerHTML = `
       <div style="margin:10px 0; color: green; font-weight:bold;">
         Last time: ${reps} reps at ${weights} ${last.unit} <br>
-        Try to beat that today!
+        Try to beat that today!${suggestion ? `<br>Recommended: ${suggestion}` : ''}
       </div>`;
   }
 });

--- a/progressiveOverload.js
+++ b/progressiveOverload.js
@@ -1,0 +1,47 @@
+function getLastEntry(exerciseName, workouts) {
+  if (!Array.isArray(workouts)) return null;
+  for (let i = workouts.length - 1; i >= 0; i--) {
+    const w = workouts[i];
+    if (!w || !Array.isArray(w.log)) continue;
+    const entry = w.log.find(e => e.exercise === exerciseName);
+    if (entry) return entry;
+  }
+  return null;
+}
+
+function getProgressiveOverloadSuggestion(exerciseName, workouts) {
+  const last = getLastEntry(exerciseName, workouts);
+  if (!last) return null;
+
+  const unit = last.unit || 'kg';
+  const weights = last.weightsArray || [];
+  const reps = last.repsArray || [];
+  const goal = typeof last.goal === 'number' ? last.goal : null;
+  const repGoal = typeof last.repGoal === 'number' ? last.repGoal : null;
+
+  let metWeight = true;
+  if (goal !== null) {
+    metWeight = weights.every(w => w >= goal);
+  }
+
+  let metReps = true;
+  if (repGoal !== null) {
+    metReps = reps.every(r => r >= repGoal);
+  }
+
+  if (metWeight && metReps) {
+    return `Add around 2.5 ${unit} or 1-2 reps`;
+  } else if (metWeight) {
+    return 'Add 1-2 reps';
+  } else if (metReps) {
+    return `Add around 2.5 ${unit}`;
+  }
+  return null;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { getProgressiveOverloadSuggestion };
+}
+if (typeof window !== 'undefined') {
+  window.getProgressiveOverloadSuggestion = getProgressiveOverloadSuggestion;
+}

--- a/tests/progressiveOverload.test.js
+++ b/tests/progressiveOverload.test.js
@@ -1,0 +1,42 @@
+const { getProgressiveOverloadSuggestion } = require('../progressiveOverload');
+
+describe('getProgressiveOverloadSuggestion', () => {
+  test('suggests weight and rep increase when goals met', () => {
+    const workouts = [
+      {
+        log: [
+          {
+            exercise: 'Bench',
+            weightsArray: [100, 100],
+            repsArray: [8, 8],
+            goal: 100,
+            repGoal: 8,
+            unit: 'kg'
+          }
+        ]
+      }
+    ];
+    const msg = getProgressiveOverloadSuggestion('Bench', workouts);
+    expect(msg).toMatch(/2\.5 .*kg/i);
+    expect(msg).toMatch(/1-2 reps/);
+  });
+
+  test('returns null when goals not met', () => {
+    const workouts = [
+      {
+        log: [
+          {
+            exercise: 'Squat',
+            weightsArray: [60],
+            repsArray: [5],
+            goal: 80,
+            repGoal: 8,
+            unit: 'kg'
+          }
+        ]
+      }
+    ];
+    const msg = getProgressiveOverloadSuggestion('Squat', workouts);
+    expect(msg).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add `getProgressiveOverloadSuggestion` helper and expose it for node/browser
- show suggested increment when entering an exercise
- test the progressive overload helper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b0be74948323b51036715e34527b