### PR TITLE
Fix macro adjustment sliders

### DIFF
--- a/index.html
+++ b/index.html
@@ -1353,6 +1353,8 @@ function renderMacroTargets() {
   document.getElementById("macroFatTarget").textContent = saved.fat;
   document.getElementById("macroCarbsTarget").textContent = saved.carbs;
   document.getElementById("macroCalsTarget").textContent = saved.calories;
+  const calTargetEl = document.getElementById("calTarget");
+  if (calTargetEl) calTargetEl.textContent = saved.calories;
 
   document.getElementById("macroProteinProgress").textContent = 0;
   document.getElementById("macroFatProgress").textContent = 0;
@@ -1468,12 +1470,21 @@ async function saveToAirtable(username, target) {
 }
 
   
- function saveMacroTargetsToTop(target) {
+function saveMacroTargetsToTop(target) {
     localStorage.setItem(`macroTargets_${currentUser}`, JSON.stringify(target));
     document.getElementById("macroCalsTarget").textContent    = target.calories;
     document.getElementById("macroProteinTarget").textContent = target.protein;
     document.getElementById("macroFatTarget").textContent     = target.fat;
     document.getElementById("macroCarbsTarget").textContent   = target.carbs;
+    // also reflect in the adjust section
+    const calTargetEl = document.getElementById("calTarget");
+    if (calTargetEl) calTargetEl.textContent = target.calories;
+    macroRanges = {
+      protein: { min: 0, max: target.protein },
+      fat:     { min: 0, max: target.fat },
+      carbs:   { min: 0, max: target.carbs },
+      tdee:    target.calories
+    };
   }
 
 function renderMacroSlots() {
@@ -1487,6 +1498,14 @@ function renderMacroSlots() {
     document.getElementById("proteinBar").max= saved.protein;
     document.getElementById("fatBar").max    = saved.fat;
     document.getElementById("carbBar").max   = saved.carbs;
+    const calTargetEl = document.getElementById("calTarget");
+    if (calTargetEl) calTargetEl.textContent = saved.calories;
+    macroRanges = {
+      protein: { min: 0, max: saved.protein },
+      fat:     { min: 0, max: saved.fat },
+      carbs:   { min: 0, max: saved.carbs },
+      tdee:    saved.calories
+    };
   }
 
   
@@ -1510,6 +1529,13 @@ function applyCustomCalories() {
   macroTargetFat     = fat;
   macroTargetCarbs   = carbs;
 
+  macroRanges = {
+    protein: { min: 0, max: Math.round(protein * 1.2) },
+    fat:     { min: 0, max: Math.round(fat * 1.2) },
+    carbs:   { min: 0, max: Math.round(carbs * 1.2) },
+    tdee:    customCal
+  };
+
   // Set slider values
   document.getElementById("proteinSlider").value = 0;
   document.getElementById("fatSlider").value = 0;
@@ -1520,7 +1546,11 @@ function applyCustomCalories() {
   document.getElementById("fatSlider").max = Math.round(fat * 1.2);
   document.getElementById("carbSlider").max = Math.round(carbs * 1.2);
 
+  const calTargetEl = document.getElementById("calTarget");
+  if (calTargetEl) calTargetEl.textContent = customCal;
+
   updateMacroUI();
+  adjustMacros();
 }
 
  function toggleMacroAdjust() {
@@ -2235,48 +2265,33 @@ if (savedUser) {
   const savedTargets = JSON.parse(localStorage.getItem(`macroTargets_${savedUser}`));
   if (savedTargets) {
     saveMacroTargetsToTop(savedTargets);
-    macroRanges.tdee = savedTargets.calories;
-    // show the macro adjustment sliders once ranges are known
+    macroRanges = {
+      protein: { min: 0, max: savedTargets.protein },
+      fat:     { min: 0, max: savedTargets.fat },
+      carbs:   { min: 0, max: savedTargets.carbs },
+      tdee:    savedTargets.calories
+    };
     document.getElementById("adjustMacroSection").style.display = "block";
     document.getElementById("proteinSlider").value = savedTargets.protein;
     document.getElementById("fatSlider").value     = savedTargets.fat;
     document.getElementById("carbSlider").value    = savedTargets.carbs;
     adjustMacros();
-  }    
-const saved = JSON.parse(localStorage.getItem(`macroTargets_${currentUser}`));
-  if (saved) {
-    document.getElementById("proteinSlider").value = saved.protein;
-    document.getElementById("fatSlider").value = saved.fat;
-    document.getElementById("carbSlider").value = saved.carbs;
-    macroRanges.tdee = saved.calories;
-    // show the macro adjustment sliders when ranges are generated
-    document.getElementById("adjustMacroSection").style.display = "block";
-    adjustMacros();
+  } else {
+    const sliders = [
+      { id: "proteinSlider", label: "proteinVal" },
+      { id: "fatSlider", label: "fatVal" },
+      { id: "carbSlider", label: "carbVal" }
+    ];
+    sliders.forEach(({ id, label }) => {
+      const slider = document.getElementById(id);
+      const display = document.getElementById(label);
+      if (slider && display) {
+        slider.value = 0;
+        display.textContent = "0";
+      }
+    });
+    document.getElementById("macroTotalCals").textContent = "0";
   }
-
- const sliders = [
-    { id: "proteinSlider", label: "proteinVal" },
-    { id: "fatSlider", label: "fatVal" },
-    { id: "carbSlider", label: "carbVal" }
-  ];
-
-  sliders.forEach(({ id, label }) => {
-    const slider = document.getElementById(id);
-    const display = document.getElementById(label);
-    if (slider && display) {
-      slider.value = 0;
-      display.textContent = "0";
-    }
-  });
-  
-  
-document.getElementById("proteinSlider").value = 0;
-  document.getElementById("fatSlider").value = 0;
-  document.getElementById("carbSlider").value = 0;
-  document.getElementById("proteinVal").textContent = "0";
-  document.getElementById("fatVal").textContent = "0";
-  document.getElementById("carbVal").textContent = "0";
-  document.getElementById("macroTotalCals").textContent = "0";
     
 
     
@@ -2338,6 +2353,24 @@ window.removeLogEntry = removeLogEntry;             // ✅ Add this
   window.loadTemplateDropdown = loadTemplateDropdown;
   window.showHistoryMiniTab = showHistoryMiniTab;
   window.renderWorkoutHistory = renderWorkoutHistory;
+
+  function showToast(msg) {
+    const toast = document.createElement('div');
+    toast.textContent = msg;
+    toast.style.position = 'fixed';
+    toast.style.bottom = '20px';
+    toast.style.left = '50%';
+    toast.style.transform = 'translateX(-50%)';
+    toast.style.background = '#333';
+    toast.style.color = '#fff';
+    toast.style.padding = '8px 16px';
+    toast.style.borderRadius = '4px';
+    toast.style.zIndex = '1000';
+    document.body.appendChild(toast);
+    setTimeout(() => toast.remove(), 3000);
+  }
+
+  window.showToast = showToast;
 function openMacroSettings() {
   // Hide the main macros content and reveal the settings view
   document.getElementById('macrosMainContent').style.display = 'none';


### PR DESCRIPTION
## Summary
- ensure macro target ranges persist when saved
- only clear macro sliders if no saved targets exist
- add simple `showToast` helper for feedback

## Testing
- `npm install`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ad58387c832382178cb70125f3b4