### PR TITLE
Load Airtable config from backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+node_modules

--- a/README.md
+++ b/README.md
@@ -11,3 +11,18 @@ npm install
 npm test
 ```
 
+## Server Configuration
+
+`server.js` exposes a `/config` endpoint that provides the Airtable credentials. Create a `.env` file with the following variables before starting the server:
+
+```bash
+AIRTABLE_TOKEN=yourTokenHere
+AIRTABLE_BASE_ID=yourBaseIdHere
+```
+
+Run the server with:
+
+```bash
+npm start
+```
+

--- a/index.html
+++ b/index.html
@@ -444,8 +444,19 @@
 <script>
 
   
-const airtableToken = 'patHs7yemB2TYuOOc.6ed847f094d08b1d30710f9f5763d909d1841a2e7dc63fbdac208133a39ae577';
-const airtableBaseId = 'appmjr4IgnEH72K1b';
+let airtableToken = '';
+let airtableBaseId = '';
+
+async function fetchAirtableConfig() {
+  try {
+    const res = await fetch(`${serverUrl}/config`);
+    const cfg = await res.json();
+    airtableToken = cfg.airtableToken;
+    airtableBaseId = cfg.airtableBaseId;
+  } catch (err) {
+    console.error('Failed to load Airtable configuration', err);
+  }
+}
 const usersTableName = 'Users';
 const templatesTableName = 'Templates';
 const MacroTargetsTableName = 'MacroTargets';  
@@ -2250,7 +2261,9 @@ function showHistoryMiniTab(tab) {
 
 
 
-  document.addEventListener("DOMContentLoaded", () => {
+  document.addEventListener("DOMContentLoaded", async () => {
+
+    await fetchAirtableConfig();
 
     // initial setup for macros
     checkMacroReset();

--- a/package.json
+++ b/package.json
@@ -4,10 +4,15 @@
   "description": "",
   "main": "script.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "start": "node server.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "dotenv": "^16.0.0",
+    "express": "^4.18.0"
+  }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.get('/config', (req, res) => {
+  res.json({
+    airtableToken: process.env.AIRTABLE_TOKEN || '',
+    airtableBaseId: process.env.AIRTABLE_BASE_ID || ''
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- pull Airtable token and base ID from backend instead of hard-coding
- expose `/config` endpoint in a new Express server
- update startup instructions in README
- ignore `.env` file

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841dec3f7d48323a0efb0640fe9c41a