### PR TITLE
Fix duplicate addition in template exercises

### DIFF
--- a/index.html
+++ b/index.html
@@ -1106,15 +1106,6 @@ function addExerciseToTemplate() {
   setsInput.value = '';
   repsInput.value = '';
   rpeInput.value = '';
-  const input = document.getElementById('newTemplateExercise');
-  if (!input) return;
-  newTemplateExercises.push(name);
-  {
-    const li = document.createElement('li');
-    li.textContent = name;
-    list.appendChild(li);
-  }
-  input.value = '';
 }
 
 function saveSimpleTemplate() {


### PR DESCRIPTION
## Summary
- avoid pushing exercise name separately when adding exercises to a template

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f5f3faa08323bbda97132cca61d0