### PR TITLE
Add frontend config fallback for Airtable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,17 @@ Run the server with:
 npm start
 ```
 
+## Front-End Configuration
+
+The web app reads Airtable credentials from a small `config.js` file at
+runtime. Copy `config.example.js` to `config.js` and fill in your values:
+
+```bash
+cp config.example.js config.js
+# edit config.js and set AIRTABLE_TOKEN and AIRTABLE_BASE_ID
+```
+
+Optionally, set `SERVER_URL` if you are running the Express backend that
+exposes the `/config` route. Leaving it blank will load the credentials directly
+from `config.js`.
+

--- a/config.example.js
+++ b/config.example.js
@@ -1,0 +1,8 @@
+// Copy this file to config.js and fill in your Airtable credentials.
+// Optionally set SERVER_URL if your backend exposes a /config endpoint.
+
+window.SERVER_URL = '';
+window.airtableConfig = {
+  airtableToken: '',
+  airtableBaseId: ''
+};

--- a/index.html
+++ b/index.html
@@ -448,6 +448,8 @@
 
 <script src="archiveOldWorkouts.js"></script>
 <script src="progressiveOverload.js"></script>
+<!-- Optional runtime configuration -->
+<script src="config.js"></script>
 <script>
 
   
@@ -455,13 +457,25 @@ let airtableToken = '';
 let airtableBaseId = '';
 
 async function fetchAirtableConfig() {
-  try {
-    const res = await fetch(`${serverUrl}/config`);
-    const cfg = await res.json();
-    airtableToken = cfg.airtableToken;
-    airtableBaseId = cfg.airtableBaseId;
-  } catch (err) {
-    console.error('Failed to load Airtable configuration', err);
+  if (serverUrl) {
+    try {
+      const res = await fetch(`${serverUrl}/config`);
+      if (res.ok) {
+        const cfg = await res.json();
+        airtableToken = cfg.airtableToken;
+        airtableBaseId = cfg.airtableBaseId;
+        if (airtableToken && airtableBaseId) return;
+      }
+    } catch (err) {
+      console.warn('Server config fetch failed', err);
+    }
+  }
+  if (window.airtableConfig) {
+    airtableToken = window.airtableConfig.airtableToken || airtableToken;
+    airtableBaseId = window.airtableConfig.airtableBaseId || airtableBaseId;
+  }
+  if (!airtableToken || !airtableBaseId) {
+    console.error('Failed to load Airtable configuration');
   }
 }
 const usersTableName = 'Users';
@@ -646,7 +660,9 @@ window.toggleWorkoutDetails = toggleWorkoutDetails;
 // Expose showTab globally for sidebar navigation
 window.showTab = showTab;
 
-const serverUrl = 'https://traininglog-backend.onrender.com'; // your server address
+// If SERVER_URL is provided in config.js, requests will be sent there.
+// Otherwise requests will be relative to the current page.
+const serverUrl = typeof window.SERVER_URL === 'string' ? window.SERVER_URL : '';
 let currentUser = null;
   
 function editSetValue(workoutIndex, entryIndex, type, value, setIndex) {


### PR DESCRIPTION
## Summary
- allow index.html to read Airtable credentials from a local `config.js`
- document the new setup steps in README
- provide a `config.example.js` template

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843241401848323ab1b8d2bc236dc08