### PR TITLE
Revamp color scheme

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,13 +7,16 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <style>
     :root {
-      --bg-color: #f9f9fb;
-      --text-color: #222;
-      --primary: #007bff;
-      --primary-dark: #0056b3;
+      --bg-color: #000000;
+      --text-color: #000000;
+      --secondary-text: #B0B9C3;
+      --primary: #2F80ED;
+      --primary-dark: #1B64C2;
       --danger: #dc3545;
-      --card-bg: #fff;
-      --border-color: #ddd;
+      --card-bg: #FFFFFF;
+      --border-color: #D9D9D9;
+      --sidebar-bg: #0D2A55;
+      --highlight: #F2994A;
       --shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
     }
     body {
@@ -45,7 +48,7 @@
     }
     input::placeholder,
     textarea::placeholder {
-      color: #888;
+      color: var(--secondary-text);
     }
     input:focus, select:focus, textarea:focus {
       outline: none;
@@ -59,7 +62,7 @@
       box-sizing: border-box;
       border-radius: 6px;
       background-color: var(--primary);
-      color: #fff;
+      color: var(--text-color);
       border: none;
       cursor: pointer;
       font-size: 15px;
@@ -95,7 +98,7 @@
       left: -250px; /* hidden */
       width: 250px;
       height: 100%;
-      background-color: #fff;
+      background-color: var(--sidebar-bg);
       box-shadow: 2px 0 5px rgba(0,0,0,0.3);
       overflow-y: auto;
       transition: left 0.3s ease;
@@ -140,7 +143,7 @@
 
 .side-menu ul li a {
   text-decoration: none;
-  color: #333;
+  color: var(--text-color);
   font-weight: bold;
   font-size: 16px;
   display: block; /* make the entire item clickable */
@@ -151,8 +154,8 @@
 
 .side-menu ul li a:hover,
 .side-menu ul li a.active {
-  background-color: var(--primary); /* blue background on hover/active */
-  color: white; /* white text on hover/active */
+  background-color: var(--primary); /* accent background on hover/active */
+  color: var(--text-color); /* ensure menu text is readable */
 }
 
 
@@ -163,8 +166,8 @@
   left: 15px;  /* some spacing from left */
   z-index: 1100; /* make sure it’s above the sidebar content */
   font-size: 28px;
-  background-color: var(--primary); /* blue background */
-  color: white;
+  background-color: var(--primary); /* accent color */
+  color: var(--text-color);
   border: none;
   cursor: pointer;
   padding: 12px 16px; /* a bit more padding for a bigger button */
@@ -174,7 +177,7 @@
   transition: background-color 0.3s ease;
 }
 .menu-toggle:hover {
-  background-color: #0056b3; /* darker blue on hover */
+  background-color: var(--primary-dark); /* darker blue on hover */
 }
 
 
@@ -195,7 +198,7 @@
       width: 100%;
       padding: 10px;
       background-color: var(--danger);
-      color: #fff;
+      color: var(--text-color);
       border: none;
       border-radius: 6px;
       box-shadow: var(--shadow);
@@ -208,16 +211,16 @@
 
 #macrosSettingsBtn {
   background-color: var(--primary);
-  color: white;
+  color: var(--text-color);
   border: none;
   padding: 4px 8px;
   border-radius: 4px;
   cursor: pointer;
   font-size: 12px;
-
+  transition: background-color 0.3s ease;
 }
 #macrosSettingsBtn:hover {
-  background-color: #0056b3;
+  background-color: var(--primary-dark);
 }
 
 #goBackBtn {
@@ -225,6 +228,14 @@
   padding: 6px 12px;
   font-size: 14px;
   cursor: pointer;
+  background-color: var(--primary);
+  color: var(--text-color);
+  border: none;
+  border-radius: 4px;
+  transition: background-color 0.3s ease;
+}
+#goBackBtn:hover {
+  background-color: var(--primary-dark);
 }
 
     
@@ -798,7 +809,7 @@ function getSetInputHTML(i) {
       <label style="min-width: 60px;">Set ${i + 1}</label>
       <input type="number" id="reps_${i}" placeholder="Reps" style="width: 80px;" />
       <input type="number" id="weight_${i}" placeholder="Weight" style="width: 100px;" />
-      <button onclick="removeSet(${i})" style="background-color: #dc3545; color: white; border: none; padding: 4px 8px; border-radius: 4px;">❌</button>
+      <button onclick="removeSet(${i})" style="background-color: #dc3545; color: var(--text-color); border: none; padding: 4px 8px; border-radius: 4px;">❌</button>
     </div>
   `;
 }
@@ -1427,7 +1438,7 @@ function handleExerciseBlur() {
     const reps = last.repsArray.join(', ');
     const weights = last.weightsArray.join(', ');
     msgDiv.innerHTML = `
-      <div style="margin:10px 0; color: green; font-weight:bold;">
+      <div style="margin:10px 0; color: var(--highlight); font-weight:bold;">
         Last time: ${reps} reps at ${weights} ${last.unit} <br>
         Try to beat that today!${suggestion ? `<br>Recommended: ${suggestion}` : ''}
       </div>`;
@@ -1440,7 +1451,7 @@ function addMacroMeal() {
     const idx = macroMeals.length;
     const container = document.getElementById("macroMealContainer");
     container.insertAdjacentHTML("beforeend", `
-      <div id="meal${idx}" style="border:1px solid #ccc; padding:10px; margin:10px 0;">
+      <div id="meal${idx}" style="border:1px solid var(--border-color); padding:10px; margin:10px 0;">
         <button data-idx="${idx}" class="toggle-meal">➕ Meal ${idx+1}</button>
         <div id="mealContent${idx}" style="display:block; margin-top:10px;">
           <label>Protein:</label>
@@ -2233,7 +2244,7 @@ function renderWorkoutHistory() {
     .sort((a, b) => new Date(b.date) - new Date(a.date))
     .forEach(workout => {
       const div = document.createElement("div");
-      div.style.border = "1px solid #ccc";
+      div.style.border = "1px solid var(--border-color)";
       div.style.padding = "10px";
       div.style.marginTop = "10px";
 
@@ -2347,7 +2358,7 @@ function addCrossfitExercise() {
   const index = crossfitExercises.length;
 
   container.innerHTML += `
-    <div style="border:1px solid #ccc; padding:10px; margin-top:10px;">
+    <div style="border:1px solid var(--border-color); padding:10px; margin-top:10px;">
       <input type="text" placeholder="Exercise Name" id="cfExerciseName${index}">
       <input type="number" placeholder="Sets" id="cfExerciseSets${index}">
       <input type="number" placeholder="Reps per Set" id="cfExerciseReps${index}">
@@ -2561,7 +2572,7 @@ function renderCrossfitWorkouts() {
     `).join('');
 
     container.innerHTML += `
-      <div style="border:1px solid #ccc; padding:10px; margin-top:10px;">
+      <div style="border:1px solid var(--border-color); padding:10px; margin-top:10px;">
         <strong>${wod.date} - ${wod.name}</strong><br>
         Time: ${wod.minutes}m ${wod.seconds}s<br>
         Rounds: ${wod.rounds || '-'}<br>
@@ -2609,7 +2620,7 @@ function addCrossfitEntry() {
 function renderCrossfitEntries() {
   const container = document.getElementById('crossfitWorkoutsContainer');
   container.innerHTML = crossfitEntries.map((entry, index) => `
-    <div style="padding:10px; border:1px solid #ccc; margin-bottom:8px;">
+    <div style="padding:10px; border:1px solid var(--border-color); margin-bottom:8px;">
       <strong>${entry.exercise}</strong><br>
       Sets: ${entry.sets} | Reps: ${entry.reps} | Weight: ${entry.weight || 'Bodyweight'} kg<br>
       Notes: ${entry.notes || 'None'}
@@ -2796,8 +2807,8 @@ window.saveSimpleTemplate = saveSimpleTemplate;
     toast.style.bottom = '20px';
     toast.style.left = '50%';
     toast.style.transform = 'translateX(-50%)';
-    toast.style.background = '#333';
-    toast.style.color = '#fff';
+    toast.style.background = 'var(--highlight)';
+    toast.style.color = 'var(--text-color)';
     toast.style.padding = '8px 16px';
     toast.style.borderRadius = '4px';
     toast.style.zIndex = '1000';


### PR DESCRIPTION
## Summary
- implement new navy sidebar and accent palette
- use CSS variables for text, highlight and border colours
- add transitions and consistent styling for buttons and notifications
- update borders in dynamic HTML to use the new variable
- set app background to black
- update main text color to black

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844536029588323ba69d6f5e55736b3