### PR TITLE
Add community feature placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # TrainingLog
 
 This project contains a simple fitness tracker.
+It now includes a **Community** tab for experimenting with group
+workouts. Users can create groups in the browser and post simple
+updates. A small leaderboard helper ranks members based on provided
+consistency and improvement scores. These features are purely
+client-side placeholders.
 
 ## Running Tests
 

--- a/community.js
+++ b/community.js
@@ -1,0 +1,65 @@
+// Community features (incomplete placeholder)
+
+let groups = JSON.parse(localStorage.getItem('communityGroups')) || [];
+
+function saveGroups() {
+  localStorage.setItem('communityGroups', JSON.stringify(groups));
+}
+
+function createGroup(name) {
+  if (!name) return null;
+  const g = { id: Date.now(), name, members: [], posts: [] };
+  groups.push(g);
+  saveGroups();
+  return g;
+}
+
+function getGroups() {
+  return groups;
+}
+
+function addPost(groupId, user, text) {
+  const g = groups.find(gr => gr.id === groupId);
+  if (!g) return;
+  g.posts.push({ user, text, date: new Date().toISOString() });
+  saveGroups();
+}
+
+function calculateLeaderboard(members) {
+  if (!Array.isArray(members)) return { consistent: [], improving: [] };
+  const byConsistent = [...members].sort((a,b) => (b.consistencyScore||0) - (a.consistencyScore||0));
+  const byImprove = [...members].sort((a,b) => (b.improvementScore||0) - (a.improvementScore||0));
+  return {
+    consistent: byConsistent.slice(0,3).map(m => m.name),
+    improving: byImprove.slice(0,3).map(m => m.name)
+  };
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { calculateLeaderboard, createGroup, getGroups, addPost };
+}
+if (typeof window !== 'undefined') {
+  window.createGroup = createGroup;
+  window.loadGroups = () => renderGroups(getGroups());
+  window.showCreateGroup = showCreateGroup;
+  window.addPostToGroup = addPost;
+}
+
+function renderGroups(list) {
+  const container = document.getElementById('groupList');
+  if (!container) return;
+  container.innerHTML = '';
+  list.forEach(g => {
+    const div = document.createElement('div');
+    div.textContent = g.name;
+    container.appendChild(div);
+  });
+}
+
+function showCreateGroup() {
+  const name = prompt('Group name?');
+  if (!name) return;
+  createGroup(name);
+  renderGroups(groups);
+}
+

--- a/index.html
+++ b/index.html
@@ -274,6 +274,7 @@
       <li><a href="#" data-tab="macroTab">🍽️ Macros</a></li>
       <li><a href="#" data-tab="crossfitTab">💪 CrossFit</a></li>
       <li><a href="#" data-tab="programTab">🗓️ Program</a></li>
+      <li><a href="#" data-tab="communityTab">👥 Community</a></li>
       <li><a href="#" data-tab="logHistoryTab">📜 Log History</a></li>
       <li><button id="sidebarLogoutBtn" onclick="logout()">Logout</button></li>
     </ul>
@@ -406,6 +407,14 @@
   <button onclick="startProgram()">Start Program</button>
 </div>
 
+<div id="communityTab" class="tab-content" style="display:none;">
+  <h2>Community</h2>
+  <div id="groupList"></div>
+  <button onclick="showCreateGroup()">Create Group</button>
+  <button onclick="loadGroups()">Refresh Groups</button>
+  <div id="groupDetail" style="display:none;"></div>
+</div>
+
   <div id="cardioTab" class="tab-content">
     <h2>Cardio Tracker</h2>
     <input type="text" id="cardioType" placeholder="Type (e.g. Running)">
@@ -513,6 +522,7 @@
 
 <script src="archiveOldWorkouts.js"></script>
 <script src="progressiveOverload.js"></script>
+<script src="community.js"></script>
 <!-- Optional runtime configuration -->
 <script src="config.js"></script>
 <script>

--- a/server.js
+++ b/server.js
@@ -5,12 +5,27 @@ dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+app.use(express.json());
+
+const groups = [];
 
 app.get('/config', (req, res) => {
   res.json({
     airtableToken: process.env.AIRTABLE_TOKEN || 'patHs7yemB2TYuOOc.6ed847f094d08b1d30710f9f5763d909d1841a2e7dc63fbdac208133a39ae577',
     airtableBaseId: process.env.AIRTABLE_BASE_ID || 'appmjr4IgnEH72K1b'
   });
+});
+
+app.get('/api/groups', (req, res) => {
+  res.json(groups);
+});
+
+app.post('/api/groups', (req, res) => {
+  const { name } = req.body;
+  if (!name) return res.status(400).json({ error: 'name required' });
+  const group = { id: groups.length + 1, name, members: [] };
+  groups.push(group);
+  res.json(group);
 });
 
 app.listen(PORT, () => {

--- a/tests/leaderboard.test.js
+++ b/tests/leaderboard.test.js
@@ -1,0 +1,17 @@
+const { calculateLeaderboard } = require('../community');
+
+describe('calculateLeaderboard', () => {
+  test('returns top 3 consistent and improving members', () => {
+    const members = [
+      { name: 'A', consistencyScore: 5, improvementScore: 1 },
+      { name: 'B', consistencyScore: 10, improvementScore: 2 },
+      { name: 'C', consistencyScore: 7, improvementScore: 8 },
+      { name: 'D', consistencyScore: 1, improvementScore: 3 }
+    ];
+    const lb = calculateLeaderboard(members);
+    expect(lb.consistent[0]).toBe('B');
+    expect(lb.consistent).toContain('C');
+    expect(lb.improving[0]).toBe('C');
+    expect(lb.improving).toContain('D');
+  });
+});


### PR DESCRIPTION
## Summary
- add notes about community tab to README
- add Community tab UI and script loader
- implement placeholder community logic and leaderboard helper
- expose basic group endpoints on the server
- test leaderboard calculation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445b2a3c3c832399bb8658dba2e244