### PR TITLE
Expand community feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,27 @@
 # TrainingLog
 
 This project contains a simple fitness tracker.
+It now includes a **Community** tab for experimenting with group
+workouts. Users can create groups in the browser and post simple
+updates. A small leaderboard helper ranks members based on provided
+consistency and improvement scores. These features are purely
+client-side placeholders.
+
+## Community API
+
+When running the Express server, a small set of community endpoints is
+available:
+
+- `POST /community/groups` – create a new group by name. Include a
+  `creatorId` field in the body and the creator is added to the group.
+- `GET /community/groups?userId=USER` – list the groups that contain the
+  specified user.
+- `POST /community/groups/:groupId/share` – share a program with the
+  group.
+- `GET /community/groups/:groupId/progress` – return a summary of member
+  progress and a simple leaderboard.
+- `POST /community/groups/:groupId/posts` – add a comment to the group
+  (use `GET` on the same path to fetch posts).
 
 ## Running Tests
 

--- a/community.js
+++ b/community.js
@@ -1,0 +1,203 @@
+// Community features (incomplete placeholder)
+
+let groups = [];
+if (typeof localStorage !== 'undefined') {
+  groups = JSON.parse(localStorage.getItem('communityGroups')) || [];
+}
+
+function saveGroups() {
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem('communityGroups', JSON.stringify(groups));
+  }
+}
+
+async function createGroup(name) {
+  if (!name) return null;
+  if (typeof fetch !== 'undefined' && window && window.currentUser) {
+    try {
+      const res = await fetch('/community/groups', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, creatorId: window.currentUser })
+      });
+      const g = await res.json();
+      groups.push(g);
+      return g;
+    } catch (e) {
+      console.warn('createGroup failed', e);
+    }
+  }
+  const g = { id: Date.now(), name, members: [], posts: [] };
+  groups.push(g);
+  saveGroups();
+  return g;
+}
+
+function getGroups() {
+  return groups;
+}
+
+async function fetchGroups(userId) {
+  if (!userId || typeof fetch === 'undefined') return getGroups();
+  try {
+    const res = await fetch(`/community/groups?userId=${encodeURIComponent(userId)}`);
+    if (res.ok) {
+      groups = await res.json();
+      saveGroups();
+    }
+  } catch (e) {
+    console.warn('fetchGroups failed', e);
+  }
+  return groups;
+}
+
+async function addPost(groupId, user, text) {
+  const g = groups.find(gr => gr.id === groupId);
+  if (!g) return;
+  if (typeof fetch !== 'undefined') {
+    try {
+      await fetch(`/community/groups/${groupId}/posts`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId: user, text })
+      });
+    } catch (e) {
+      console.warn('addPost failed', e);
+    }
+  }
+  g.posts.push({ user, text, date: new Date().toISOString() });
+  saveGroups();
+}
+
+async function fetchPosts(groupId) {
+  try {
+    const res = await fetch(`/community/groups/${groupId}/posts`);
+    if (res.ok) {
+      const posts = await res.json();
+      const g = groups.find(gr => gr.id === groupId);
+      if (g) {
+        g.posts = posts;
+        saveGroups();
+      }
+      return posts;
+    }
+  } catch (e) {
+    console.warn('fetchPosts failed', e);
+  }
+  const g = groups.find(gr => gr.id === groupId);
+  return (g && g.posts) || [];
+}
+
+async function shareProgram(groupId, programData) {
+  if (typeof fetch === 'undefined' || !window.currentUser) return;
+  try {
+    await fetch(`/community/groups/${groupId}/share`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ senderId: window.currentUser, programData })
+    });
+  } catch (e) {
+    console.warn('shareProgram failed', e);
+  }
+}
+
+async function fetchProgress(groupId) {
+  try {
+    const res = await fetch(`/community/groups/${groupId}/progress`);
+    if (res.ok) return await res.json();
+  } catch (e) {
+    console.warn('fetchProgress failed', e);
+  }
+  return null;
+}
+
+function calculateLeaderboard(members) {
+  if (!Array.isArray(members)) return { consistent: [], improving: [] };
+  const byConsistent = [...members].sort((a,b) => (b.consistencyScore||0) - (a.consistencyScore||0));
+  const byImprove = [...members].sort((a,b) => (b.improvementScore||0) - (a.improvementScore||0));
+  return {
+    consistent: byConsistent.slice(0,3).map(m => m.name),
+    improving: byImprove.slice(0,3).map(m => m.name)
+  };
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    calculateLeaderboard,
+    createGroup,
+    getGroups,
+    addPost,
+    fetchGroups,
+    fetchPosts,
+    shareProgram,
+    fetchProgress
+  };
+}
+if (typeof window !== 'undefined') {
+  window.createGroup = createGroup;
+  window.loadGroups = () => fetchGroups(window.currentUser).then(renderGroups);
+  window.showCreateGroup = showCreateGroup;
+  window.addPostToGroup = addPost;
+  window.shareProgramToGroup = shareProgram;
+  window.loadGroupProgress = fetchProgress;
+  window.loadPosts = fetchPosts;
+  window.loadGroupStats = loadGroupStats;
+}
+
+function renderGroups(list) {
+  const container = document.getElementById('groupList');
+  if (!container) return;
+  container.innerHTML = '';
+  list.forEach(g => {
+    const div = document.createElement('div');
+    div.textContent = g.name;
+    div.className = 'group-item';
+    div.onclick = () => openGroup(g.id);
+    container.appendChild(div);
+  });
+}
+
+async function openGroup(id) {
+  const group = groups.find(gr => gr.id === id);
+  if (!group) return;
+  const detail = document.getElementById('groupDetail');
+  if (!detail) return;
+  detail.style.display = 'block';
+  await fetchPosts(id);
+  const postsHtml = (group.posts || [])
+    .sort((a,b) => new Date(a.date)-new Date(b.date))
+    .map(p => `<div><strong>${p.user}</strong>: ${p.text} <small>${new Date(p.date).toLocaleString()}</small></div>`)
+    .join('');
+  detail.innerHTML = `
+    <h3>${group.name}</h3>
+    <div id="groupPosts">${postsHtml}</div>
+    <textarea id="newPostText"></textarea>
+    <button onclick="addPostToGroup(${id}, window.currentUser, document.getElementById('newPostText').value)">Post</button>
+    <h4>Share Program</h4>
+    <textarea id="shareProgramData"></textarea>
+    <button onclick="shareProgramToGroup(${id}, document.getElementById('shareProgramData').value)">Share</button>
+    <button onclick="loadGroupStats(${id})">Load Progress</button>
+    <div id="groupProgress"></div>
+  `;
+}
+
+async function loadGroupStats(id) {
+  const data = await fetchProgress(id);
+  const div = document.getElementById('groupProgress');
+  if (!div || !data) return;
+  const rows = (data.members || [])
+    .map(m => `<tr><td>${m.userId}</td><td>${m.volume||0}</td><td>${m.reps||0}</td></tr>`) 
+    .join('');
+  const lb = data.leaderboard;
+  div.innerHTML = `
+    <table><tr><th>User</th><th>Volume</th><th>Reps</th></tr>${rows}</table>
+    <p>Most Consistent: ${lb.consistent.join(', ')}</p>
+    <p>Most Improving: ${lb.improving.join(', ')}</p>`;
+}
+
+function showCreateGroup() {
+  const name = prompt('Group name?');
+  if (!name) return;
+  createGroup(name).then(() => renderGroups(groups));
+}
+

--- a/index.html
+++ b/index.html
@@ -274,6 +274,7 @@
       <li><a href="#" data-tab="macroTab">🍽️ Macros</a></li>
       <li><a href="#" data-tab="crossfitTab">💪 CrossFit</a></li>
       <li><a href="#" data-tab="programTab">🗓️ Program</a></li>
+      <li><a href="#" data-tab="communityTab">👥 Community</a></li>
       <li><a href="#" data-tab="logHistoryTab">📜 Log History</a></li>
       <li><button id="sidebarLogoutBtn" onclick="logout()">Logout</button></li>
     </ul>
@@ -406,6 +407,14 @@
   <button onclick="startProgram()">Start Program</button>
 </div>
 
+<div id="communityTab" class="tab-content" style="display:none;">
+  <h2>Community</h2>
+  <div id="groupList"></div>
+  <button onclick="showCreateGroup()">Create Group</button>
+  <button onclick="loadGroups()">Refresh Groups</button>
+  <div id="groupDetail" style="display:none;"></div>
+</div>
+
   <div id="cardioTab" class="tab-content">
     <h2>Cardio Tracker</h2>
     <input type="text" id="cardioType" placeholder="Type (e.g. Running)">
@@ -513,6 +522,7 @@
 
 <script src="archiveOldWorkouts.js"></script>
 <script src="progressiveOverload.js"></script>
+<script src="community.js"></script>
 <!-- Optional runtime configuration -->
 <script src="config.js"></script>
 <script>
@@ -677,6 +687,10 @@ function showTab(tabName) {
 
   if (tabName === "logTab") {
     checkActiveProgram();
+  }
+
+  if (tabName === "communityTab") {
+    loadGroups();
   }
 
   // Always reset macros view to main content on tab change

--- a/server.js
+++ b/server.js
@@ -5,12 +5,88 @@ dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+app.use(express.json());
+
+const { calculateLeaderboard } = require('./community');
+
+const groups = [];
 
 app.get('/config', (req, res) => {
   res.json({
     airtableToken: process.env.AIRTABLE_TOKEN || 'patHs7yemB2TYuOOc.6ed847f094d08b1d30710f9f5763d909d1841a2e7dc63fbdac208133a39ae577',
     airtableBaseId: process.env.AIRTABLE_BASE_ID || 'appmjr4IgnEH72K1b'
   });
+});
+
+// Groups API
+app.get('/community/groups', (req, res) => {
+  const { userId } = req.query;
+  if (userId) {
+    const filtered = groups.filter(g => (g.members || []).includes(userId));
+    return res.json(filtered);
+  }
+  res.json(groups);
+});
+
+app.post('/community/groups', (req, res) => {
+  const { name, creatorId } = req.body;
+  if (!name || !creatorId) {
+    return res.status(400).json({ error: 'name and creatorId required' });
+  }
+  const group = {
+    id: groups.length + 1,
+    name,
+    members: [creatorId],
+    sharedPrograms: [],
+    progress: {},
+    posts: [],
+    programId: null
+  };
+  groups.push(group);
+  res.json(group);
+});
+
+// Posts
+app.get('/community/groups/:groupId/posts', (req, res) => {
+  const g = groups.find(gr => gr.id === Number(req.params.groupId));
+  if (!g) return res.status(404).json({ error: 'group not found' });
+  res.json(g.posts || []);
+});
+
+app.post('/community/groups/:groupId/posts', (req, res) => {
+  const g = groups.find(gr => gr.id === Number(req.params.groupId));
+  if (!g) return res.status(404).json({ error: 'group not found' });
+  const { userId, text } = req.body;
+  if (!userId || !text) return res.status(400).json({ error: 'userId and text required' });
+  if (!Array.isArray(g.posts)) g.posts = [];
+  g.posts.push({ userId: Number(userId), text, date: new Date().toISOString() });
+  res.json({ ok: true });
+});
+
+// Program sharing API
+app.post('/community/groups/:groupId/share', (req, res) => {
+  const { groupId } = req.params;
+  const g = groups.find(gr => gr.id === Number(groupId));
+  if (!g) return res.status(404).json({ error: 'group not found' });
+  const { senderId, programData } = req.body;
+  if (!senderId || !programData) {
+    return res.status(400).json({ error: 'senderId and programData required' });
+  }
+  g.sharedPrograms.push({ senderId, programData });
+  res.json({ ok: true });
+});
+
+// Progress and leaderboard API
+app.get('/community/groups/:groupId/progress', (req, res) => {
+  const { groupId } = req.params;
+  const g = groups.find(gr => gr.id === Number(groupId));
+  if (!g) return res.status(404).json({ error: 'group not found' });
+  const members = Object.entries(g.progress || {}).map(([id, data]) => ({
+    userId: id,
+    ...data
+  }));
+  const lb = calculateLeaderboard(members);
+  res.json({ members, leaderboard: lb });
 });
 
 app.listen(PORT, () => {

--- a/tests/leaderboard.test.js
+++ b/tests/leaderboard.test.js
@@ -1,0 +1,17 @@
+const { calculateLeaderboard } = require('../community');
+
+describe('calculateLeaderboard', () => {
+  test('returns top 3 consistent and improving members', () => {
+    const members = [
+      { name: 'A', consistencyScore: 5, improvementScore: 1 },
+      { name: 'B', consistencyScore: 10, improvementScore: 2 },
+      { name: 'C', consistencyScore: 7, improvementScore: 8 },
+      { name: 'D', consistencyScore: 1, improvementScore: 3 }
+    ];
+    const lb = calculateLeaderboard(members);
+    expect(lb.consistent[0]).toBe('B');
+    expect(lb.consistent).toContain('C');
+    expect(lb.improving[0]).toBe('C');
+    expect(lb.improving).toContain('D');
+  });
+});


### PR DESCRIPTION
## Summary
- document community API in README
- implement group, post and progress routes in server
- rework community.js with server integration and group detail UI
- load community groups when tab is opened

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dotenv)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445b2a3c3c832399bb8658dba2e244