### PR TITLE
Fix community tab script errors

### DIFF
--- a/community.js
+++ b/community.js
@@ -179,6 +179,26 @@ async function loadGroupStats(id) {
     <p>Most Improving: ${lb.improving.join(', ')}</p>`;
 }
 
+// wrapper helpers for inline onclick handlers
+function addPostToGroup(id, user, text) {
+  if (!text) return;
+  addPost(id, user, text);
+  // re-render group to show new post
+  openGroup(id);
+}
+
+function shareProgramToGroup(id, dataStr) {
+  if (!dataStr) return;
+  let parsed;
+  try {
+    parsed = JSON.parse(dataStr);
+  } catch (e) {
+    console.warn('Invalid program data', e);
+    return;
+  }
+  shareProgram(id, parsed);
+}
+
 function showCreateGroup() {
   const name = prompt('Group name?');
   if (!name) return;
@@ -187,3 +207,5 @@ function showCreateGroup() {
 
 window.loadGroups = loadGroups;
 window.showCreateGroup = showCreateGroup;
+window.addPostToGroup = addPostToGroup;
+window.shareProgramToGroup = shareProgramToGroup;

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ dotenv.config();
 const app = express();
 const PORT = process.env.PORT || 3000;
 app.use(express.json());
+app.use(express.static(__dirname));
 
 const { calculateLeaderboard } = require('./community');
 


### PR DESCRIPTION
## Summary
- serve static files from Express
- implement helpers used by community tab

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446587d2788323963aa901639af101