### PR TITLE
Add progress charts tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,7 +245,8 @@
 
     
     
-  </style>
+</style>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 
  
@@ -275,6 +276,7 @@
       <li><a href="#" data-tab="crossfitTab">💪 CrossFit</a></li>
       <li><a href="#" data-tab="programTab">🗓️ Program</a></li>
       <li><a href="#" data-tab="communityTab">👥 Community</a></li>
+      <li><a href="#" data-tab="progressTab">📈 Progress</a></li>
       <li><a href="#" data-tab="logHistoryTab">📜 Log History</a></li>
       <li><button id="sidebarLogoutBtn" onclick="logout()">Logout</button></li>
     </ul>
@@ -503,6 +505,13 @@
 
 
 
+  <div id="progressTab" class="tab-content" style="display:none;">
+    <h2>Progress Overview</h2>
+    <canvas id="workoutChart" style="max-width:100%;"></canvas>
+    <canvas id="cardioChart" style="max-width:100%; margin-top:20px;"></canvas>
+    <canvas id="weightChart" style="max-width:100%; margin-top:20px;"></canvas>
+  </div>
+
 <div id="logHistoryTab" class="tab-content" style="display:none;">
   <h2>Log History</h2>
   <div id="historyNav" style="margin-bottom:10px;">
@@ -701,6 +710,10 @@ function showTab(tabName) {
 
   if (tabName === "logHistoryTab") {
     showHistoryMiniTab('workout');
+  }
+
+  if (tabName === "progressTab") {
+    renderProgressCharts();
   }
 }
 
@@ -1006,6 +1019,9 @@ function renderWorkouts() {
   });
 
   renderWorkoutHistory();
+  if (document.getElementById('progressTab').classList.contains('active')) {
+    renderProgressCharts();
+  }
 
   window.renderWorkouts = renderWorkouts;
   window.toggleWorkoutDetails = toggleWorkoutDetails;
@@ -2299,6 +2315,9 @@ function renderWeights() {
   log.forEach((entry, index) => {
     body.innerHTML += `<tr><td>${entry.date}</td><td>${entry.weight}</td><td>${entry.calories ?? '-'}</td><td>${entry.cardio ?? '-'}</td><td><button onclick="removeWeightEntry(${index})" class="remove-btn">❌</button></td></tr>`;
   });
+  if (document.getElementById('progressTab').classList.contains('active')) {
+    renderProgressCharts();
+  }
 }
 
 function removeWeightEntry(index) {
@@ -2354,6 +2373,9 @@ function renderCardio() {
   log.forEach((entry, index) => {
     body.innerHTML += `<tr><td>${entry.date}</td><td>${entry.type}</td><td>${entry.duration}</td><td>${entry.distance || '-'}</td><td>${entry.calories || '-'}</td><td>${entry.notes}</td><td><button onclick="removeCardioEntry(${index})" class="remove-btn">❌</button></td></tr>`;
   });
+  if (document.getElementById('progressTab').classList.contains('active')) {
+    renderProgressCharts();
+  }
 }
 
 function removeCardioEntry(index) {
@@ -2362,6 +2384,58 @@ function removeCardioEntry(index) {
   localStorage.setItem(`cardioLog_${currentUser}`, JSON.stringify(log));
   renderCardio();
   updateMacroUI();
+}
+
+let workoutChart, cardioChart, weightChart;
+
+function renderProgressCharts() {
+  const workouts = JSON.parse(localStorage.getItem(`workouts_${currentUser}`)) || [];
+  const workoutData = workouts.map(w => ({
+    date: w.date,
+    volume: calculateWorkoutVolume(w)
+  })).sort((a,b)=>a.date.localeCompare(b.date));
+  const wDates = workoutData.map(d=>d.date);
+  const wVols = workoutData.map(d=>d.volume);
+
+  const cardio = JSON.parse(localStorage.getItem(`cardioLog_${currentUser}`)) || [];
+  cardio.sort((a,b)=>a.date.localeCompare(b.date));
+  const cDates = cardio.map(e=>e.date);
+  const cDur = cardio.map(e=>e.duration);
+
+  const weights = JSON.parse(localStorage.getItem(`bodyweightLog_${currentUser}`)) || [];
+  weights.sort((a,b)=>a.date.localeCompare(b.date));
+  const bwDates = weights.map(e=>e.date);
+  const bw = weights.map(e=>e.weight);
+  const start = bw[0] || 0;
+  const change = bw.map(v=>v - start);
+
+  if (workoutChart) workoutChart.destroy();
+  if (cardioChart) cardioChart.destroy();
+  if (weightChart) weightChart.destroy();
+
+  const ctx1 = document.getElementById('workoutChart').getContext('2d');
+  workoutChart = new Chart(ctx1, {
+    type: 'line',
+    data: { labels: wDates, datasets: [{ label: 'Volume', data: wVols, borderColor: 'blue', fill:false }] },
+    options: { scales: { y: { beginAtZero: true } } }
+  });
+
+  const ctx2 = document.getElementById('cardioChart').getContext('2d');
+  cardioChart = new Chart(ctx2, {
+    type: 'line',
+    data: { labels: cDates, datasets: [{ label: 'Duration (min)', data: cDur, borderColor: 'green', fill:false }] },
+    options: { scales: { y: { beginAtZero: true } } }
+  });
+
+  const ctx3 = document.getElementById('weightChart').getContext('2d');
+  weightChart = new Chart(ctx3, {
+    type: 'line',
+    data: { labels: bwDates, datasets: [
+      { label: 'Weight', data: bw, borderColor: 'orange', fill:false },
+      { label: 'Change', data: change, borderColor: 'red', fill:false }
+    ] },
+    options: { scales: { y: { beginAtZero: false } } }
+  });
 }
 
 
@@ -2815,6 +2889,7 @@ window.loadTodayProgram = loadTodayProgram;
 window.toggleTemplateBuilder = toggleTemplateBuilder;
 window.addExerciseToTemplate = addExerciseToTemplate;
 window.saveSimpleTemplate = saveSimpleTemplate;
+window.renderProgressCharts = renderProgressCharts;
 
   function showToast(msg) {
     const toast = document.createElement('div');


### PR DESCRIPTION
## Summary
- add new Progress tab to sidebar
- show workout, cardio and bodyweight charts
- render charts on demand and update when logs change
- load Chart.js from CDN for graph rendering

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849958de4dc832395e2f7a4a6d88485