### PR TITLE
Fix hidden dashboard on auto-login

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,7 +312,7 @@
  
 <body>
 
-<div id="loginContainer" style="max-width:400px;margin:40px auto;background:var(--card-bg);padding:20px;box-shadow:var(--shadow);border-radius:10px;color:#000;">
+<div id="loginContainer" class="section active" style="max-width:400px;margin:40px auto;background:var(--card-bg);padding:20px;box-shadow:var(--shadow);border-radius:10px;color:#000;">
   <h2>Login to Pocket Coach</h2>
   <input type="text" id="username" placeholder="Enter Username" />
   <input type="password" id="password" placeholder="Enter Password" />
@@ -3035,22 +3035,28 @@ function loadCrossfitTemplate() {
 }
     
     
+  const loginEl = document.getElementById("loginContainer");
+  const dash = document.getElementById("dashboardContainer");
+
   if (savedUser) {
-  currentUser = savedUser;
-  document.getElementById("userDisplay").textContent = savedUser;
-  document.getElementById("loginContainer").style.display = "none";
-  document.getElementById("dashboardContainer").style.display = "block";
-  showTab("logTab");
-  renderWorkouts();
-  renderWeights();
-  renderCardio();
-  renderCrossfitWorkouts();
-  loadTemplateDropdown();
-  loadProgramTemplates();
-  loadProgramDropdown();
-  checkActiveProgram();
-  loadUserExercises();
-}
+    currentUser = savedUser;
+    document.getElementById("userDisplay").textContent = savedUser;
+    loginEl.style.display = "none";
+    animateSwitch(dash);
+    showTab("logTab");
+    renderWorkouts();
+    renderWeights();
+    renderCardio();
+    renderCrossfitWorkouts();
+    loadTemplateDropdown();
+    loadProgramTemplates();
+    loadProgramDropdown();
+    checkActiveProgram();
+    loadUserExercises();
+  } else {
+    activeSection = loginEl;
+    loginEl.classList.add("active");
+  }
 
 
   const savedTargets = JSON.parse(localStorage.getItem(`macroTargets_${savedUser}`));


### PR DESCRIPTION
## Summary
- trigger animation when restoring dashboard for saved users
- mark login container as an active section and set `activeSection` when no saved user

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df1f354dc8323b18929443eec9218