### PR TITLE
Fix unmatched brace causing JavaScript syntax error

### DIFF
--- a/index.html
+++ b/index.html
@@ -3069,9 +3069,8 @@ function loadCrossfitTemplate() {
   loadTemplateDropdown();
   loadProgramTemplates();
   loadProgramDropdown();
-  checkActiveProgram();
-  loadUserExercises();
-})
+    checkActiveProgram();
+    loadUserExercises();
 
 
   const savedTargets = JSON.parse(localStorage.getItem(`macroTargets_${savedUser}`));


### PR DESCRIPTION
## Summary
- remove stray closing paren in DOMContentLoaded block

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfb07e2c88323817e5544c23e5344