### PR TITLE
Fix module undefined error in community.js

### DIFF
--- a/community.js
+++ b/community.js
@@ -270,4 +270,6 @@ if (typeof window !== 'undefined') {
 }
 
 // allow tests to import functions
-module.exports = { calculateLeaderboard };
+if (typeof module !== 'undefined') {
+  module.exports = { calculateLeaderboard };
+}


### PR DESCRIPTION
## Summary
- guard the Node module export in `community.js` so browsers don't throw `module is not defined`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852c6149b3c8323a258d40775217999