### PR TITLE
Fix sidebar shift and show hamburger

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,8 +147,9 @@
       body {
         max-width: none;
       }
+      /* Keep menu button visible on wider screens */
       #menuToggle {
-        display: none;
+        display: block;
       }
     }
 
@@ -383,7 +384,7 @@
     </ul>
   </nav>
 
-  <div class="main-content">
+  <div id="appContainer" class="main-content">
 
 <div id="progressReminder"></div>
 


### PR DESCRIPTION
## Summary
- add missing `id="appContainer"` to main content to let sidebar shift it
- keep hamburger menu button visible on wide screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854249966988323b26b9b6792430c88