### PR TITLE
Add floating action menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -334,6 +334,43 @@
   to { transform: rotate(360deg); }
 }
 
+/* Floating FAB container */
+#fabContainer {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 999;
+}
+.fab {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background-color: var(--primary);
+  color: #fff;
+  font-size: 32px;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+}
+.fab-menu {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 10px;
+  gap: 8px;
+}
+.fab-menu.hidden {
+  display: none;
+}
+.fab-menu button {
+  padding: 8px 12px;
+  border: none;
+  background-color: #fff;
+  color: var(--text-color);
+  border-radius: 4px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.2);
+  text-align: left;
+}
+
     
     
 </style>
@@ -417,12 +454,17 @@
   </div>
 
   
-  <!-- Action buttons -->
-  <button onclick="addLogEntry()">Add to Log</button>
-  <button onclick="completeWorkout()">Complete Workout</button>
-  <button onclick="saveWorkoutAsTemplate()">Save Current Workout as Template</button>
-   <button onclick="loadSelectedTemplate()">Load a Saved Template</button>
-  <button onclick="loadTodayProgram()">Load Program</button>
+  <!-- Floating action menu -->
+  <div id="fabContainer">
+    <button id="fabToggle" class="fab">＋</button>
+    <div id="fabMenu" class="fab-menu hidden">
+      <button onclick="addLogEntry()">➕ Add to Log</button>
+      <button onclick="completeWorkout()">✅ Complete Workout</button>
+      <button onclick="saveWorkoutAsTemplate()">📦 Save Template</button>
+      <button onclick="loadSelectedTemplate()">📂 Load Template</button>
+      <button onclick="loadTodayProgram()">🏃 Load Program</button>
+    </div>
+  </div>
   
   <!-- Logs will render below this -->
   <div id="workoutsContainer" style="margin-top: 20px;"></div>
@@ -2375,6 +2417,12 @@ function closeMacroSettings() {
 window.openMacroSettings = openMacroSettings;
 window.closeMacroSettings = closeMacroSettings;
 
+
+  // Toggle FAB menu
+  document.getElementById('fabToggle').addEventListener('click', () => {
+    const menu = document.getElementById('fabMenu');
+    menu.classList.toggle('hidden');
+  });
   
 // LOGOUT
 function logout() {


### PR DESCRIPTION
## Summary
- implement a floating action button menu for workout actions
- style FAB and its menu
- handle show/hide behavior via JS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68542e089c9883239815baab32fc8def