### PR TITLE
Center FAB and restore menu labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -334,6 +334,47 @@
   to { transform: rotate(360deg); }
 }
 
+/* Floating FAB container */
+#fabContainer {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 999;
+}
+.fab {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background-color: var(--primary);
+  color: #fff;
+  font-size: 32px;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.fab-menu {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 10px;
+  gap: 8px;
+}
+.fab-menu.hidden {
+  display: none;
+}
+.fab-menu button {
+  padding: 8px 12px;
+  border: none;
+  background-color: #fff;
+  color: var(--text-color);
+  border-radius: 4px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.2);
+  text-align: left;
+}
+
     
     
 </style>
@@ -417,12 +458,17 @@
   </div>
 
   
-  <!-- Action buttons -->
-  <button onclick="addLogEntry()">Add to Log</button>
-  <button onclick="completeWorkout()">Complete Workout</button>
-  <button onclick="saveWorkoutAsTemplate()">Save Current Workout as Template</button>
-   <button onclick="loadSelectedTemplate()">Load a Saved Template</button>
-  <button onclick="loadTodayProgram()">Load Program</button>
+  <!-- Floating action menu -->
+  <div id="fabContainer">
+    <button id="fabToggle" class="fab">＋</button>
+    <div id="fabMenu" class="fab-menu hidden">
+      <button onclick="addLogEntry()">➕ Add to Log</button>
+      <button onclick="completeWorkout()">✅ Complete Workout</button>
+      <button onclick="saveWorkoutAsTemplate()">📦 Save Current Workout as Template</button>
+      <button onclick="loadSelectedTemplate()">📂 Load a Saved Template</button>
+      <button onclick="loadTodayProgram()">🏃 Load Program</button>
+    </div>
+  </div>
   
   <!-- Logs will render below this -->
   <div id="workoutsContainer" style="margin-top: 20px;"></div>
@@ -2375,6 +2421,12 @@ function closeMacroSettings() {
 window.openMacroSettings = openMacroSettings;
 window.closeMacroSettings = closeMacroSettings;
 
+
+  // Toggle FAB menu
+  document.getElementById('fabToggle').addEventListener('click', () => {
+    const menu = document.getElementById('fabMenu');
+    menu.classList.toggle('hidden');
+  });
   
 // LOGOUT
 function logout() {


### PR DESCRIPTION
## Summary
- center the floating action button at the bottom of the page
- ensure plus icon is centered within the button
- restore full text labels in the action menu

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68542e089c9883239815baab32fc8def