### PR TITLE
Enhance resistance layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,11 +187,11 @@
 /* hamburger button always top-left, above content */
 .menu-toggle {
   position: fixed;
-  top: 12px;
-  left: 12px;
+  top: 16px;
+  left: 16px;
   width: 48px;
   height: 48px;
-  z-index: 2000;
+  z-index: 1100;
   font-size: 24px;
   background-color: var(--primary);
   color: #fff;
@@ -206,6 +206,17 @@
 }
 .menu-toggle:hover {
   background-color: #0056b3;
+}
+#menuToggle {
+  position: fixed;
+  top: 16px;
+  left: 16px;
+  transform: none;
+  z-index: 1100;
+  width: 48px;
+  height: 48px;
+  padding: 0;
+  font-size: 24px;
 }
 
 
@@ -425,10 +436,10 @@
 
 #training-calendar {
   width: 100%;
-  max-width: 400px;
+  max-width: 500px;
   margin: 20px auto;
   border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
   overflow: hidden;
 }
 
@@ -464,9 +475,10 @@
     
 #resistance-section{
   display:grid;
-  grid-template-columns:1fr 1fr;
-  gap:20px;
-  align-items:flex-start;
+  grid-template-columns:1fr 1.2fr;
+  column-gap:24px;
+  align-items:start;
+  margin-bottom:80px;
 }
 #resistance-inputs{
   display:flex;
@@ -476,13 +488,21 @@
 #resistance-inputs input,
 #resistance-inputs select{
   width:100%;
-  max-width:300px;
+  max-width:280px;
 }
 #training-calendar{
   width:100%;
-  max-width:400px;
+  max-width:500px;
   height:auto;
   margin-top:0;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+}
+#training-calendar .calendar-container{
+  transform: translateY(-20px);
+  transition: transform 0.3s ease;
+}
+#training-calendar:hover{
+  transform: translateY(-10px);
 }
 .highlight-past{background-color:#FFE0B2;}
 .highlight-today{background-color:#FF7043;}


### PR DESCRIPTION
## Summary
- tune layout for resistance log section
- resize inputs and calendar
- restyle hamburger button
- animate training calendar container

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556d9b68e48323a58aa23e04f3fd2b