### PR TITLE
Move menu toggle back to left

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,9 +209,8 @@
 }
 #menuToggle {
   position: fixed;
-  bottom: 100px;
-  left: 50%;
-  transform: translateX(-50%);
+  top: 16px;
+  left: 16px;
   z-index: 1100;
   width: 56px;
   height: 56px;


### PR DESCRIPTION
## Summary
- restore tab menu toggle positioning on the left

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855bfc7d09483238842f68ad7231948