### PR TITLE
Fix duplicate renderExerciseProgress function

### DIFF
--- a/index.html
+++ b/index.html
@@ -2875,10 +2875,6 @@ function renderExerciseProgress() {
   const workouts = JSON.parse(localStorage.getItem(`workouts_${currentUser}`)) || [];
   const progressMap = {};
 
-function renderExerciseProgress() {
-  const workouts = JSON.parse(localStorage.getItem(`workouts_${currentUser}`)) || [];
-  const progressMap = {};
-
   // gather last two entries for each exercise
   workouts.sort((a, b) => a.date.localeCompare(b.date));
   workouts.forEach(w => {


### PR DESCRIPTION
## Summary
- remove the duplicated `renderExerciseProgress` stub from `index.html`

## Testing
- `node -c script.js` *(syntax check on extracted script)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab5a2512083239abf8d399c6df63c