### PR TITLE
Enhance progress tab with analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -858,14 +858,22 @@
         <button onclick="showCardioProgress()">Cardio</button>
         <button onclick="showBodyweightProgress()">Bodyweight</button>
         <button onclick="showExerciseProgress()">Exercise</button>
+        <input type="date" id="startRange" onchange="refreshProgress()">
+        <input type="date" id="endRange" onchange="refreshProgress()">
+        <button onclick="promptGoal()">Set Goal</button>
       </nav>
       <section class="progress-chart">
         <canvas id="progressCanvas"></canvas>
         <div id="exerciseProgress" style="display:none;"></div>
+        <div id="goalBar" style="margin-top:10px;"></div>
+        <div id="coachCorner" style="margin-top:10px;"></div>
       </section>
       <aside class="progress-calendar">
         <div id="progressCalendar"></div>
+        <div id="prPanel"></div>
+        <div id="milestoneBadges"></div>
       </aside>
+      <button onclick="exportCSV()">Export CSV</button>
     </div>
   </div>
 
@@ -900,6 +908,11 @@
 <script src="community.js"></script>
 <!-- Optional runtime configuration -->
 <script src="config.js"></script>
+<script src="progressUtils.js"></script>
+<script src="progressMilestones.js"></script>
+<script src="progressAnalytics.js"></script>
+<script src="progressGoals.js"></script>
+<script src="progressAI.js"></script>
 <script>
 
 let currentUser = null;
@@ -1310,6 +1323,12 @@ function addLogEntry() {
   });
 
   localStorage.setItem(`workouts_${currentUser}`, JSON.stringify(workouts));
+  updatePRs(currentUser, { log: [{ exercise, weightsArray, repsArray }] }, calculateWorkoutVolume);
+  updateGoalProgress(currentUser, 'volume', calculateWorkoutVolume({ log: [{ weightsArray, repsArray }] }));
+  renderPRs();
+  renderMilestones();
+  renderGoalBar();
+  showCoachInsights();
   saveUserExercise(exercise);
   trackWorkoutDate(date);
   renderWorkouts();
@@ -2858,14 +2877,18 @@ function removeCardioEntry(index) {
 
 let progressChart;
 
-function renderLineChart(labels, label, data) {
+function renderLineChart(labels, label, data, trend, forecast) {
   const ctx = document.getElementById('progressCanvas').getContext('2d');
   if (progressChart) progressChart.destroy();
   progressChart = new Chart(ctx, {
     type: 'line',
     data: {
       labels,
-      datasets: [{ label, data, tension: .4 }]
+      datasets: [
+        { label, data, tension: .4 },
+        trend ? { label: 'Trend', data: trend, borderDash: [5,5], borderColor: '#888', tension:.4, fill:false } : null,
+        forecast ? { label: 'Forecast', data: forecast, borderColor: '#f00', borderDash: [2,2], tension:.4, fill:false } : null
+      ].filter(Boolean)
     },
     options: { scales: { y: { beginAtZero: true } } }
   });
@@ -2909,6 +2932,18 @@ async function fetchWorkoutHistory() {
   return workouts.map(w => ({ date: w.date, volume: calculateWorkoutVolume(w) }));
 }
 
+function applyDateRange(history) {
+  const start = document.getElementById('startRange').value;
+  const end = document.getElementById('endRange').value;
+  if (!start && !end) return history;
+  return history.filter(h => {
+    const d = h.date;
+    if (start && d < start) return false;
+    if (end && d > end) return false;
+    return true;
+  });
+}
+
 async function fetchCardioHistory() {
   const cardio = JSON.parse(localStorage.getItem(`cardioLog_${currentUser}`)) || [];
   return cardio.map(c => ({ date: c.date, duration: c.duration }));
@@ -2921,35 +2956,124 @@ async function fetchBodyweightHistory() {
 
 async function showWorkoutProgress() {
   const history = await fetchWorkoutHistory();
-  const dates = history.map(h => h.date);
-  const vols = history.map(h => h.volume);
+  const filtered = applyDateRange(history);
+  const dates = filtered.map(h => h.date);
+  const vols = filtered.map(h => h.volume);
   document.getElementById('exerciseProgress').style.display = 'none';
   document.getElementById('progressCanvas').style.display = 'block';
-  renderLineChart(dates, 'Total Volume', vols);
+  const trend = trendPoints(vols);
+  const forecast = Array(dates.length-1).fill(null).concat(forecastNext(vols, 4));
+  renderLineChart(dates.concat(new Array(4).fill('')), 'Total Volume', vols.concat(new Array(4).fill(null)), trend.concat(new Array(4).fill(null)), forecast);
 }
 
 async function showCardioProgress() {
   const history = await fetchCardioHistory();
-  const dates = history.map(h => h.date);
-  const mins = history.map(h => h.duration);
+  const filtered = applyDateRange(history);
+  const dates = filtered.map(h => h.date);
+  const mins = filtered.map(h => h.duration);
   document.getElementById('exerciseProgress').style.display = 'none';
   document.getElementById('progressCanvas').style.display = 'block';
-  renderLineChart(dates, 'Cardio Minutes', mins);
+  const trend = trendPoints(mins);
+  const forecast = Array(dates.length-1).fill(null).concat(forecastNext(mins, 4));
+  renderLineChart(dates.concat(new Array(4).fill('')), 'Cardio Minutes', mins.concat(new Array(4).fill(null)), trend.concat(new Array(4).fill(null)), forecast);
 }
 
 async function showBodyweightProgress() {
   const history = await fetchBodyweightHistory();
-  const dates = history.map(h => h.date);
-  const weights = history.map(h => h.weight);
+  const filtered = applyDateRange(history);
+  const dates = filtered.map(h => h.date);
+  const weights = filtered.map(h => h.weight);
   document.getElementById('exerciseProgress').style.display = 'none';
   document.getElementById('progressCanvas').style.display = 'block';
-  renderLineChart(dates, 'Bodyweight', weights);
+  const trend = trendPoints(weights);
+  const forecast = Array(dates.length-1).fill(null).concat(forecastNext(weights, 4));
+  renderLineChart(dates.concat(new Array(4).fill('')), 'Bodyweight', weights.concat(new Array(4).fill(null)), trend.concat(new Array(4).fill(null)), forecast);
 }
 
 function showExerciseProgress() {
   document.getElementById('progressCanvas').style.display = 'none';
   document.getElementById('exerciseProgress').style.display = 'block';
   renderExerciseProgress();
+}
+
+function refreshProgress() {
+  if (document.getElementById('workoutTabBtn')?.classList.contains('active') || true) {
+    showWorkoutProgress();
+  }
+}
+
+function renderPRs() {
+  const prs = loadPRs(currentUser);
+  const panel = document.getElementById('prPanel');
+  if (!panel) return;
+  panel.innerHTML = '<h3>PRs</h3>';
+  Object.entries(prs).forEach(([ex, pr]) => {
+    const div = document.createElement('div');
+    div.textContent = `${ex}: 1RM ${pr.oneRM.toFixed(1)}, Vol ${pr.volume.toFixed(1)}`;
+    panel.appendChild(div);
+  });
+}
+
+function renderMilestones() {
+  const workouts = JSON.parse(localStorage.getItem(`workouts_${currentUser}`)) || [];
+  const milestones = checkMilestones(currentUser, workouts, calculateWorkoutVolume);
+  const cont = document.getElementById('milestoneBadges');
+  if (!cont) return;
+  cont.innerHTML = '';
+  milestones.forEach(m => {
+    const span = document.createElement('span');
+    span.textContent = m;
+    span.style.marginRight = '5px';
+    cont.appendChild(span);
+  });
+}
+
+function renderGoalBar() {
+  const goals = loadGoals(currentUser);
+  const bar = document.getElementById('goalBar');
+  if (!bar) return;
+  const g = goals['volume'];
+  if (!g) { bar.textContent = 'No goal set'; return; }
+  const pct = Math.min(100, (g.progress / g.target) * 100);
+  bar.innerHTML = `<div style="background:#eee;width:100%;height:10px;position:relative;"><div style="background:var(--primary);width:${pct}%;height:10px;"></div></div><small>${g.progress}/${g.target}</small>`;
+}
+
+function promptGoal() {
+  const target = parseFloat(prompt('Enter volume goal (kg):')); 
+  if (isNaN(target)) return; 
+  setGoal(currentUser, 'volume', target); 
+  renderGoalBar();
+}
+
+function showCoachInsights() {
+  const prs = loadPRs(currentUser);
+  const insights = simpleInsights(Object.fromEntries(Object.entries(prs).map(([k,v])=>[k,[v]])));
+  const corner = document.getElementById('coachCorner');
+  if (!corner) return;
+  corner.innerHTML = '';
+  insights.forEach(t => {
+    const div = document.createElement('div');
+    div.textContent = t;
+    div.style.border = '1px solid #ccc';
+    div.style.padding = '5px';
+    corner.appendChild(div);
+  });
+}
+
+function exportCSV() {
+  const history = JSON.parse(localStorage.getItem(`workouts_${currentUser}`)) || [];
+  const rows = [['Date','Exercise','Sets','Reps','Weight']];
+  history.forEach(w => {
+    (w.log||[]).forEach(e => {
+      rows.push([w.date, e.exercise, e.sets, e.repsArray.join('|'), e.weightsArray.join('|')]);
+    });
+  });
+  const csv = rows.map(r => r.join(',')).join('\n');
+  const blob = new Blob([csv], {type:'text/csv'});
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'workouts.csv';
+  a.click();
 }
 
 
@@ -3001,6 +3125,9 @@ function renderTrainingCalendar(month, year) {
   const trackedDates = getLocalStorage('workoutDates');
   const active = getActiveProgram();
   const programDates = active ? getProgramDayDates(active.startDate) : [];
+  const workouts = JSON.parse(localStorage.getItem(`workouts_${currentUser}`)) || [];
+  const volumeMap = {};
+  workouts.forEach(w => { volumeMap[w.date] = calculateWorkoutVolume(w); });
 
   cal.innerHTML = '';
 
@@ -3064,7 +3191,11 @@ function renderTrainingCalendar(month, year) {
     const str = current.toISOString().split('T')[0];
     const td = document.createElement('td');
     td.textContent = day;
-    if (trackedDates.includes(str)) td.classList.add("highlight-past");
+    const vol = volumeMap[str] || 0;
+    if (vol) {
+      const shade = Math.min(1, vol / 500);
+      td.style.backgroundColor = `rgba(0,128,0,${shade})`;
+    }
     if (programDates.includes(str)) td.classList.add("highlight-today");
     if (str === new Date().toISOString().split('T')[0]) td.style.border = '2px solid var(--primary)';
     td.onclick = () => goToDate(str);
@@ -3530,6 +3661,9 @@ function loadCrossfitTemplate() {
   // Show the first tab initially
   initTrainingCalendar();
   showTab("logTab");
+  renderPRs();
+  renderMilestones();
+  renderGoalBar();
 
 
 
@@ -3580,6 +3714,9 @@ window.showBodyweightProgress = showBodyweightProgress;
 window.showExerciseProgress = showExerciseProgress;
 window.renderExerciseProgress = renderExerciseProgress;
 window.goToDate = goToDate;
+window.refreshProgress = refreshProgress;
+window.promptGoal = promptGoal;
+window.exportCSV = exportCSV;
 
   function showToast(msg) {
     const toast = document.createElement('div');

--- a/progressAI.js
+++ b/progressAI.js
@@ -1,0 +1,24 @@
+function simpleInsights(prsHistory, weeks=3) {
+  const tips = [];
+  Object.entries(prsHistory).forEach(([exercise, records]) => {
+    const arr = records.slice(-weeks);
+    if (arr.length >= 2) {
+      const first = arr[0].oneRM || 0;
+      const last = arr[arr.length - 1].oneRM || 0;
+      if (first && last > first) {
+        const pct = ((last - first) / first) * 100;
+        if (pct >= 5) {
+          tips.push(`You improved ${exercise} 1RM by ${pct.toFixed(1)}% in ${weeks} weeks—consider increasing accessory sets.`);
+        }
+      }
+    }
+  });
+  return tips;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { simpleInsights };
+}
+if (typeof window !== 'undefined') {
+  window.simpleInsights = simpleInsights;
+}

--- a/progressAnalytics.js
+++ b/progressAnalytics.js
@@ -1,0 +1,40 @@
+function linearRegression(data) {
+  const n = data.length;
+  if (!n) return { m: 0, b: 0 };
+  let sumX = 0, sumY = 0, sumXY = 0, sumX2 = 0;
+  for (let i = 0; i < n; i++) {
+    const x = i + 1;
+    const y = data[i];
+    sumX += x;
+    sumY += y;
+    sumXY += x * y;
+    sumX2 += x * x;
+  }
+  const m = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX);
+  const b = (sumY - m * sumX) / n;
+  return { m, b };
+}
+
+function trendPoints(data) {
+  const { m, b } = linearRegression(data);
+  return data.map((_, i) => m * (i + 1) + b);
+}
+
+function forecastNext(data, weeks) {
+  const { m, b } = linearRegression(data);
+  const results = [];
+  const start = data.length + 1;
+  for (let i = 0; i < weeks; i++) {
+    results.push(m * (start + i) + b);
+  }
+  return results;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { linearRegression, trendPoints, forecastNext };
+}
+if (typeof window !== 'undefined') {
+  window.linearRegression = linearRegression;
+  window.trendPoints = trendPoints;
+  window.forecastNext = forecastNext;
+}

--- a/progressGoals.js
+++ b/progressGoals.js
@@ -1,0 +1,43 @@
+function loadGoals(user) {
+  if (typeof localStorage === 'undefined') return {};
+  return JSON.parse(localStorage.getItem(`goals_${user}`)) || {};
+}
+
+function saveGoals(user, goals) {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(`goals_${user}`, JSON.stringify(goals));
+}
+
+function setGoal(user, type, target) {
+  const goals = loadGoals(user);
+  goals[type] = { target, progress: 0 };
+  saveGoals(user, goals);
+  return goals[type];
+}
+
+function updateGoalProgress(user, type, amount) {
+  const goals = loadGoals(user);
+  if (!goals[type]) return null;
+  goals[type].progress = (goals[type].progress || 0) + amount;
+  saveGoals(user, goals);
+  return goals[type];
+}
+
+function checkMissedWorkouts(user, threshold, days) {
+  const dates = JSON.parse(localStorage.getItem(`workoutDates_${user}`)) || [];
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - days);
+  const recent = dates.filter(d => new Date(d) >= cutoff);
+  return recent.length < threshold;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { loadGoals, saveGoals, setGoal, updateGoalProgress, checkMissedWorkouts };
+}
+if (typeof window !== 'undefined') {
+  window.loadGoals = loadGoals;
+  window.saveGoals = saveGoals;
+  window.setGoal = setGoal;
+  window.updateGoalProgress = updateGoalProgress;
+  window.checkMissedWorkouts = checkMissedWorkouts;
+}

--- a/progressMilestones.js
+++ b/progressMilestones.js
@@ -1,0 +1,44 @@
+function loadWorkoutDates(user) {
+  if (typeof localStorage === 'undefined') return [];
+  return JSON.parse(localStorage.getItem(`workoutDates_${user}`)) || [];
+}
+
+function calculateStreak(dates) {
+  const sorted = dates.slice().sort();
+  let streak = 0;
+  for (let i = sorted.length - 1; i >= 0; i--) {
+    const d = new Date(sorted[i]);
+    const compare = new Date();
+    compare.setDate(compare.getDate() - streak);
+    if (d.toISOString().split('T')[0] === compare.toISOString().split('T')[0]) {
+      streak++;
+    } else {
+      break;
+    }
+  }
+  return streak;
+}
+
+function totalVolume(workouts, volumeCalc) {
+  if (!Array.isArray(workouts)) return 0;
+  return workouts.reduce((t, w) => t + volumeCalc(w), 0);
+}
+
+function checkMilestones(user, workouts, volumeCalc) {
+  const dates = loadWorkoutDates(user);
+  const streak = calculateStreak(dates);
+  const volume = totalVolume(workouts, volumeCalc);
+  const milestones = [];
+  if (streak >= 30) milestones.push('🏅 30-day streak');
+  if (volume >= 1000) milestones.push('💪 1,000 kg total volume');
+  return milestones;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { calculateStreak, totalVolume, checkMilestones };
+}
+if (typeof window !== 'undefined') {
+  window.calculateStreak = calculateStreak;
+  window.totalVolume = totalVolume;
+  window.checkMilestones = checkMilestones;
+}

--- a/progressUtils.js
+++ b/progressUtils.js
@@ -1,0 +1,54 @@
+function computeOneRepMax(weightsArray, repsArray) {
+  if (!Array.isArray(weightsArray) || !Array.isArray(repsArray)) return 0;
+  let best = 0;
+  for (let i = 0; i < weightsArray.length; i++) {
+    const w = +weightsArray[i];
+    const r = +repsArray[i];
+    if (!w || !r) continue;
+    const est = w * (1 + r / 30);
+    if (est > best) best = est;
+  }
+  return best;
+}
+
+function loadPRs(user) {
+  if (typeof localStorage === 'undefined') return {};
+  return JSON.parse(localStorage.getItem(`prs_${user}`)) || {};
+}
+
+function savePRs(user, prs) {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(`prs_${user}`, JSON.stringify(prs));
+}
+
+function updatePRs(user, workout, volumeCalc) {
+  if (!workout || !Array.isArray(workout.log)) return null;
+  const prs = loadPRs(user);
+  let updated = false;
+  workout.log.forEach(e => {
+    const vol = volumeCalc ? volumeCalc({ log: [e] }) : 0;
+    const orm = computeOneRepMax(e.weightsArray, e.repsArray);
+    const pr = prs[e.exercise] || { oneRM: 0, volume: 0 };
+    if (orm > pr.oneRM) {
+      pr.oneRM = orm;
+      updated = true;
+    }
+    if (vol > pr.volume) {
+      pr.volume = vol;
+      updated = true;
+    }
+    prs[e.exercise] = pr;
+  });
+  if (updated) savePRs(user, prs);
+  return updated ? prs : null;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { computeOneRepMax, loadPRs, savePRs, updatePRs };
+}
+if (typeof window !== 'undefined') {
+  window.computeOneRepMax = computeOneRepMax;
+  window.loadPRs = loadPRs;
+  window.savePRs = savePRs;
+  window.updatePRs = updatePRs;
+}

--- a/tests/progressMilestones.test.js
+++ b/tests/progressMilestones.test.js
@@ -1,0 +1,9 @@
+const { calculateStreak } = require('../progressMilestones');
+
+test('calculateStreak counts consecutive days', () => {
+  const today = new Date();
+  const y1 = new Date(); y1.setDate(today.getDate()-1);
+  const y2 = new Date(); y2.setDate(today.getDate()-2);
+  const dates = [y2.toISOString().split('T')[0], y1.toISOString().split('T')[0], today.toISOString().split('T')[0]];
+  expect(calculateStreak(dates)).toBe(3);
+});

--- a/tests/progressUtils.test.js
+++ b/tests/progressUtils.test.js
@@ -1,0 +1,15 @@
+const { computeOneRepMax, updatePRs } = require('../progressUtils');
+const { calculateWorkoutVolume } = require('../calculateWorkoutVolume');
+
+test('computeOneRepMax calculates epley estimate', () => {
+  const orm = computeOneRepMax([100], [5]);
+  expect(orm).toBeCloseTo(100 * (1 + 5 / 30));
+});
+
+test('updatePRs updates record when higher', () => {
+  const user = 'testUser';
+  global.localStorage = { getItem: jest.fn(()=>null), setItem: jest.fn() };
+  const workout = { log: [{ exercise:'Bench', weightsArray:[100], repsArray:[5] }] };
+  const prs = updatePRs(user, workout, calculateWorkoutVolume);
+  expect(prs.Bench.oneRM).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary
- add utility modules for PR detection, milestones, goals and analytics
- integrate trend lines, forecast and goal progress bar in progress tab
- add heatmap calendar shading by volume
- support CSV export and simple coach insights
- add unit tests for new helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ab81af3b88323909d443468905609