### PR TITLE
Remove gym finder tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -588,7 +588,6 @@
       <li><a href="#" data-tab="programTab">🗓️ Programs</a></li>
       <li><a href="#" data-tab="communityTab">👥 Community</a></li>
       <li><a href="#" data-tab="progressTab">📈 Progress</a></li>
-      <li><a href="#" data-tab="gymFinderTab">🏋️ Gym Finder</a></li>
       <li><a href="#" data-tab="logHistoryTab">📜 Log History</a></li>
       <li><button id="sidebarLogoutBtn" onclick="logout()">Logout</button></li>
     </ul>
@@ -848,7 +847,6 @@
     </div>
   </div>
 
-<div id="gymFinderTab" class="tab-content"><h2>Gym Finder</h2><div id="gymMap" style="height:300px;background:#eee;">Map Loading...</div><div id="equipmentTags"></div></div>
 <div id="logHistoryTab" class="tab-content">
   <h2>Log History</h2>
   <div id="historyNav" style="margin-bottom:10px;">


### PR DESCRIPTION
## Summary
- remove unused gym finder tab from sidebar
- delete gym finder content section

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b19643fb483238d386e109c6589d8