### PR TITLE
UI cleanup for ProgramTab

### DIFF
--- a/ProgramTab.css
+++ b/ProgramTab.css
@@ -1,0 +1,4 @@
+.frequency-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: .5rem; }
+.inputs-grid { display: grid; grid-template-columns: 2fr 1fr; gap: 1rem; }
+fieldset { border: 1px solid #ccc; padding: 1rem; margin-bottom: 1.5rem; border-radius: 4px; }
+legend { font-weight: bold; }

--- a/ProgramTab.js
+++ b/ProgramTab.js
@@ -40,6 +40,7 @@ export default function ProgramTab() {
     startDate: '',
     frequency: [],
     progressionType: 'linear',
+    splitMode: 'synchronous',
     progressionSettings: {
       linear: {
         increment: 2.5,
@@ -113,6 +114,7 @@ export default function ProgramTab() {
       startDate: program.startDate,
       frequency: program.frequency,
       progressionType: program.progressionType,
+      splitMode: program.splitMode,
       progressionSettings: program.progressionSettings[program.progressionType],
       days: program.days.map((d, i) => ({
         name: d.name,
@@ -180,30 +182,7 @@ export default function ProgramTab() {
       ...program,
       startDate: e.target.value
     })
-  })), /*#__PURE__*/React.createElement("div", null, "Frequency:", DAYS.map(d => /*#__PURE__*/React.createElement("label", {
-    key: d,
-    style: {
-      marginRight: '6px'
-    }
-  }, /*#__PURE__*/React.createElement("input", {
-    type: "checkbox",
-    checked: program.frequency.includes(d),
-    onChange: () => handleFreqToggle(d)
-  }), " ", d))), /*#__PURE__*/React.createElement("div", null, "Progression Type:", ['linear', 'undulating', 'block'].map(t => /*#__PURE__*/React.createElement("label", {
-    key: t,
-    style: {
-      marginRight: '10px'
-    }
-  }, /*#__PURE__*/React.createElement("input", {
-    type: "radio",
-    name: "progType",
-    value: t,
-    checked: program.progressionType === t,
-    onChange: () => setProgram({
-      ...program,
-      progressionType: t
-    })
-  }), " ", t))), program.progressionType === 'linear' && /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
+  })), /*#__PURE__*/React.createElement("fieldset", null, /*#__PURE__*/React.createElement("legend", null, "Frequency"), /*#__PURE__*/React.createElement("div", { className: "frequency-grid" }, DAYS.map(d => /*#__PURE__*/React.createElement("label", { key: d }, /*#__PURE__*/React.createElement("input", { type: "checkbox", checked: program.frequency.includes(d), onChange: () => handleFreqToggle(d) }), " ", d)))), /*#__PURE__*/React.createElement("fieldset", null, /*#__PURE__*/React.createElement("legend", null, "Progression Type"), ['linear', 'undulating', 'block'].map(t => /*#__PURE__*/React.createElement("label", { key: t, style: { marginRight: '10px' } }, /*#__PURE__*/React.createElement("input", { type: "radio", name: "progType", value: t, checked: program.progressionType === t, onChange: () => setProgram({ ...program, progressionType: t }) }), " ", t))), /*#__PURE__*/React.createElement("fieldset", null, /*#__PURE__*/React.createElement("legend", null, "Split Mode"), /*#__PURE__*/React.createElement("label", null, /*#__PURE__*/React.createElement("input", { type: "radio", name: "splitMode", value: "synchronous", checked: program.splitMode === 'synchronous', onChange: () => setProgram({ ...program, splitMode: 'synchronous' }) }), " Synchronous"), /*#__PURE__*/React.createElement("label", { style: { marginLeft: '10px' } }, /*#__PURE__*/React.createElement("input", { type: "radio", name: "splitMode", value: "asynchronous", checked: program.splitMode === 'asynchronous', onChange: () => setProgram({ ...program, splitMode: 'asynchronous' }) }), " Asynchronous"))), program.progressionType === 'linear' && /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
     title: "Amount to add each interval"
   }, "Increment ", /*#__PURE__*/React.createElement("input", {
     type: "number",

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Pocket Coach</title>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="ProgramTab.css">
   <style>
     /* Center all tab headers on the page */
     .tab-content > h2,
@@ -512,7 +513,7 @@
 #resistance-inputs input,
 #resistance-inputs select{
   width:100%;
-  max-width:280px;
+  max-width:100%;
 }
 #training-calendar{
   width:100%;
@@ -603,12 +604,10 @@
 
 <div id="resistance-section">
   <div id="resistance-inputs">
+  <div class="inputs-grid">
   <input type="text" id="exercise" placeholder="Exercise" list="exerciseSuggestions" />
   <datalist id="exerciseSuggestions"></datalist>
   <input type="number" id="sets" placeholder="Sets" oninput="generateSetInputs(this.value)" />
-
-  <!-- Dynamically generated inputs will appear here -->
-  <div id="setInputsContainer"></div>
 
   <!-- Optional goals -->
   <input type="number" id="goal" placeholder="Target Weight Goal (kg/lbs)" />
@@ -619,6 +618,10 @@
     <option value="kg">kg</option>
     <option value="lbs">lbs</option>
   </select>
+  </div>
+
+  <!-- Dynamically generated inputs will appear here -->
+  <div id="setInputsContainer"></div>
 
   <!-- Date selector -->
   <input type="date" id="entryDate" class="calendar-widget slide-up" />


### PR DESCRIPTION
## Summary
- add Frequency, Progression Type, and Split Mode fieldsets
- shorten log inputs using a grid layout
- include external ProgramTab.css with basic styling
- store splitMode in programs and payload

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1b334d84832397eda00ac803ab17