### PR TITLE
Add offline mode and dark themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ updates. A small leaderboard helper ranks members based on provided
 consistency and improvement scores. These features are purely
 client-side placeholders.
 
+Recent updates added an offline action queue and a theme selector with
+two dark themes. Auto-generated workout suggestions now pre-populate set
+inputs based on your last session and a simple progression analysis will
+recommend deload weeks when plateaus are detected. Additional helper
+modules expose periodization and meal planning utilities.
+
 ## Community API
 
 When running the Express server, a small set of community endpoints is

--- a/autoProgression.js
+++ b/autoProgression.js
@@ -1,0 +1,23 @@
+import { loadPRs } from './progressUtils.js';
+
+export function analyzeProgress(user) {
+  const prs = loadPRs(user);
+  const results = [];
+  Object.entries(prs).forEach(([exercise, data]) => {
+    const history = data.history || [];
+    if (history.length >= 4) {
+      const last = history[history.length - 1];
+      const fourAgo = history[history.length - 4];
+      if (last.oneRM <= fourAgo.oneRM) {
+        results.push({ type: 'deload', exercise });
+        return;
+      }
+    }
+    results.push({ type: 'progress', exercise });
+  });
+  return results;
+}
+
+if (typeof window !== 'undefined') {
+  window.analyzeProgress = analyzeProgress;
+}

--- a/index.html
+++ b/index.html
@@ -16,10 +16,8 @@
       width: 100%;
     }
     :root {
-      --bg-color: #000000;
-      --text-color: #000000;
       --bg-color: #F9F9FB;
-      --text-color: #FFFFFF;
+      --text-color: #000000;
       --secondary-text: #B0B9C3;
       --primary: #2F80ED;
       --primary-dark: #1B64C2;
@@ -29,6 +27,22 @@
       --sidebar-bg: #0D2A55;
       --highlight: #F2994A;
       --shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+    }
+
+    body.theme-dark {
+      --bg-color: #121212;
+      --text-color: #FFFFFF;
+      --card-bg: #1E1E1E;
+      --border-color: #333;
+      --sidebar-bg: #000000;
+    }
+
+    body.theme-neon {
+      --bg-color: #000000;
+      --text-color: #39FF14;
+      --card-bg: #001100;
+      --border-color: #39FF14;
+      --sidebar-bg: #003300;
     }
     body {
       font-family: 'Poppins', sans-serif;
@@ -774,6 +788,9 @@
 
     <div id="macroMealContainer"></div>
     <button id="macroMeal" style="width: 100%; font-size: 1.1rem; padding: 12px;">➕ Add Meal</button>
+    <button onclick="scanBarcode()" style="width:100%;font-size:1rem;">📷 Scan Barcode</button>
+    <input id="recipeUrl" placeholder="Import recipe URL" style="width:100%;padding:6px;margin-top:10px;"/>
+    <button onclick="importRecipe(recipeUrl.value).then(r=>console.log(r))" style="width:100%;font-size:1rem;">Import Recipe</button>
   </div>
 
   <!-- Settings Mini Tab -->
@@ -785,6 +802,16 @@
       <label for="customCalories">Custom Calorie Intake (optional):</label><br>
       <input id="customCalories" type="number" placeholder="Enter custom calorie target" style="width: 100%; padding: 8px; margin-top: 6px;"/>
       <button onclick="applyCustomCalories()" style="width: 100%; margin-top: 10px; font-size: 1.1rem; padding: 12px;">Insert Calories</button>
+    </div>
+
+    <!-- Theme selection -->
+    <div style="margin-bottom:20px;">
+      <label for="themeSelect">Color Theme:</label><br>
+      <select id="themeSelect" onchange="applyTheme(this.value)" style="width:100%;padding:8px;margin-top:6px;">
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+        <option value="neon">Neon Dark</option>
+      </select>
     </div>
 
     <!-- Adjust Macros -->
@@ -817,6 +844,7 @@
         <option value="1.9">Extremely Active</option>
       </select>
       <button onclick="calculateMacroTargets()" style="width: 100%; font-size: 1.1rem; padding: 12px;">Calculate Targets</button>
+      <button onclick="console.log(planWeek([]))" style="width:100%;font-size:1rem;margin-top:10px;">Plan Week</button>
     </div>
   </div>
 </div>
@@ -887,6 +915,10 @@
 <script src="progressGoals.js"></script>
 <script src="progressAI.js"></script>
 <script src="gamification.js"></script>
+<script type="module" src="offline.js"></script>
+<script type="module" src="autoProgression.js"></script>
+<script type="module" src="periodization.js"></script>
+<script type="module" src="macrosFeatures.js"></script>
 <script>
 
 let currentUser = null;
@@ -1300,6 +1332,11 @@ function addLogEntry() {
   updatePRs(currentUser, { log: [{ exercise, weightsArray, repsArray }] }, calculateWorkoutVolume);
   updateGoalProgress(currentUser, 'volume', calculateWorkoutVolume({ log: [{ weightsArray, repsArray }] }));
   renderPRs();
+  const prog = analyzeProgress ? analyzeProgress(currentUser) : [];
+  const deload = prog.find(p => p.type === 'deload');
+  if (deload) {
+    showToast(`Deload recommended for ${deload.exercise}`);
+  }
   renderMilestones();
   renderGoalBar();
   showCoachInsights();
@@ -1816,14 +1853,20 @@ function completeWorkout() {
 }
 
 async function saveWorkoutToBackend(workout) {
-  await fetch(`${serverUrl}/saveWorkout`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      username: currentUser,
-      workout
-    })
-  });
+  const action = {
+    url: `${serverUrl}/saveWorkout`,
+    options: {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: currentUser, workout })
+    }
+  };
+  try {
+    await fetch(action.url, action.options);
+  } catch (err) {
+    console.warn('offline - queueing workout', err);
+    if (window.queueAction) queueAction(action);
+  }
 }
 
 async function loadWorkoutsFromBackend() {
@@ -1875,6 +1918,20 @@ function handleExerciseBlur() {
         Last time: ${reps} reps at ${weights} ${last.unit} <br>
         Try to beat that today!${suggestion ? `<br>Recommended: ${suggestion}` : ''}
       </div>`;
+
+    // auto-fill today's sets with progression
+    document.getElementById('sets').value = last.sets || last.repsArray.length;
+    generateSetInputs(last.sets || last.repsArray.length);
+    last.repsArray.forEach((r, i) => {
+      const inc = suggestion && suggestion.includes('rep') ? r + 1 : r;
+      document.getElementById(`reps_${i}`).value = inc;
+    });
+    last.weightsArray.forEach((w, i) => {
+      let val = w;
+      if (suggestion && suggestion.includes('2.5')) val = w + 2.5;
+      document.getElementById(`weight_${i}`).value = val;
+    });
+    document.getElementById('weightUnit').value = last.unit || 'kg';
   }
 }
 
@@ -3277,6 +3334,11 @@ function showHistoryMiniTab(tab) {
 
   document.addEventListener("DOMContentLoaded", async () => {
 
+    const savedTheme = localStorage.getItem('theme') || 'light';
+    applyTheme(savedTheme);
+    const sel = document.getElementById('themeSelect');
+    if (sel) sel.value = savedTheme;
+
     await fetchAirtableConfig();
 
     updateExerciseSuggestions();
@@ -3716,6 +3778,15 @@ window.exportCSV = exportCSV;
   }
 
   window.showToast = showToast;
+
+  function applyTheme(theme) {
+    document.body.classList.remove('theme-dark', 'theme-neon', 'theme-light');
+    if (theme === 'dark') document.body.classList.add('theme-dark');
+    else if (theme === 'neon') document.body.classList.add('theme-neon');
+    localStorage.setItem('theme', theme);
+  }
+
+  window.applyTheme = applyTheme;
 function openMacroSettings() {
   // Hide the main macros content and reveal the settings view
   document.getElementById('macrosMainContent').style.display = 'none';

--- a/macrosFeatures.js
+++ b/macrosFeatures.js
@@ -1,0 +1,59 @@
+export async function scanBarcode() {
+  if (!navigator.mediaDevices) {
+    alert('Camera not available');
+    return;
+  }
+  // simplified placeholder using barcode detector if available
+  if ('BarcodeDetector' in window) {
+    const detector = new BarcodeDetector({ formats: ['ean_13'] });
+    const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } });
+    const video = document.createElement('video');
+    video.srcObject = stream;
+    await video.play();
+    const canvas = document.createElement('canvas');
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(video, 0, 0);
+    const barcodes = await detector.detect(canvas);
+    stream.getTracks().forEach(t => t.stop());
+    if (barcodes[0]) return barcodes[0].rawValue;
+  }
+  alert('Barcode scanning not supported');
+}
+
+export async function importRecipe(url) {
+  try {
+    const res = await fetch(url);
+    const text = await res.text();
+    const m = text.match(/(protein|fat|carb)s?\s*:?\s*(\d+)/gi);
+    if (!m) return null;
+    const result = { protein:0, carbs:0, fat:0 };
+    m.forEach(pair => {
+      const [_, key, val] = pair.match(/(protein|fat|carb)s?\s*:?\s*(\d+)/i);
+      result[key.toLowerCase()] = Number(val);
+    });
+    return result;
+  } catch(e) {
+    console.warn('Recipe import failed', e);
+    return null;
+  }
+}
+
+export function planWeek(meals) {
+  const groceries = {};
+  meals.forEach(day => {
+    day.forEach(item => {
+      Object.entries(item).forEach(([k,v]) => {
+        groceries[k] = (groceries[k] || 0) + v;
+      });
+    });
+  });
+  return groceries;
+}
+
+if (typeof window !== 'undefined') {
+  window.scanBarcode = scanBarcode;
+  window.importRecipe = importRecipe;
+  window.planWeek = planWeek;
+}

--- a/offline.js
+++ b/offline.js
@@ -1,0 +1,31 @@
+// Simple offline action queue
+const pendingActions = JSON.parse(localStorage.getItem('pendingActions') || '[]');
+
+function savePendingActions() {
+  localStorage.setItem('pendingActions', JSON.stringify(pendingActions));
+}
+
+export function queueAction(action) {
+  pendingActions.push(action);
+  savePendingActions();
+}
+
+export async function processQueue() {
+  for (let i = 0; i < pendingActions.length; i++) {
+    const { url, options } = pendingActions[i];
+    try {
+      await fetch(url, options);
+      pendingActions.splice(i, 1);
+      i--;
+    } catch (e) {
+      console.warn('Offline queue failed', e);
+    }
+  }
+  savePendingActions();
+}
+
+window.addEventListener('online', processQueue);
+if (typeof window !== 'undefined') {
+  window.queueAction = queueAction;
+  window.processQueue = processQueue;
+}

--- a/periodization.js
+++ b/periodization.js
@@ -1,0 +1,28 @@
+export function buildPeriodizationTemplate(type, exercises) {
+  const weeks = [];
+  const loads = {
+    linear: [70, 75, 80, 85],
+    block: [60, 65, 70, 55],
+    undulating: [60, 80, 70, 85],
+    hybrid: [70, 80, 65, 90]
+  };
+  const template = loads[type] || loads.linear;
+  for (let i = 0; i < template.length; i++) {
+    weeks.push({ week: i + 1, load: template[i], exercises });
+  }
+  return weeks;
+}
+
+export function createSplitSchedule(days, exercises) {
+  const schedule = [];
+  const len = exercises.length;
+  for (let i = 0; i < days; i++) {
+    schedule.push({ day: i + 1, exercise: exercises[i % len] });
+  }
+  return schedule;
+}
+
+if (typeof window !== 'undefined') {
+  window.buildPeriodizationTemplate = buildPeriodizationTemplate;
+  window.createSplitSchedule = createSplitSchedule;
+}

--- a/progressUtils.js
+++ b/progressUtils.js
@@ -28,7 +28,7 @@ function updatePRs(user, workout, volumeCalc) {
   workout.log.forEach(e => {
     const vol = volumeCalc ? volumeCalc({ log: [e] }) : 0;
     const orm = computeOneRepMax(e.weightsArray, e.repsArray);
-    const pr = prs[e.exercise] || { oneRM: 0, volume: 0 };
+    const pr = prs[e.exercise] || { oneRM: 0, volume: 0, history: [] };
     if (orm > pr.oneRM) {
       pr.oneRM = orm;
       updated = true;
@@ -37,6 +37,8 @@ function updatePRs(user, workout, volumeCalc) {
       pr.volume = vol;
       updated = true;
     }
+    pr.history.push({ date: Date.now(), oneRM: orm });
+    if (pr.history.length > 10) pr.history.shift();
     prs[e.exercise] = pr;
   });
   if (updated) savePRs(user, prs);


### PR DESCRIPTION
## Summary
- support offline action queue
- auto-fill workout sets with suggestions
- detect plateaus via `analyzeProgress`
- add dark and neon themes selectable in settings
- expose helpers for periodization and meal planning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b1e9cb720832396a9f7426ab2db99