### PR TITLE
Fix unmatched parenthesis in ProgramTab

### DIFF
--- a/ProgramTab.js
+++ b/ProgramTab.js
@@ -323,7 +323,7 @@ export default function ProgramTab() {
     }
   }, "Share Program"), /*#__PURE__*/React.createElement("button", {
     onClick: () => setShowDrawer(false)
-  }, "Close"))), showShare && /*#__PURE__*/React.createElement("div", {
+  }, "Close")), showShare && /*#__PURE__*/React.createElement("div", {
     className: "share-modal"
   }, /*#__PURE__*/React.createElement("input", {
     id: "shareUser",


### PR DESCRIPTION
## Summary
- fix unmatched closing parenthesis in ProgramTab.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b230e44fc8323a286debc1a221548