### PR TITLE
Expose progress utils as ES module

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "presets": [["@babel/preset-env", {"targets": {"node": "current"}}]]
+}

--- a/index.html
+++ b/index.html
@@ -909,7 +909,7 @@
 <script src="community.js"></script>
 <!-- Optional runtime configuration -->
 <script src="config.js"></script>
-<script src="progressUtils.js"></script>
+<script type="module" src="progressUtils.js"></script>
 <script src="progressMilestones.js"></script>
 <script src="progressAnalytics.js"></script>
 <script src="progressGoals.js"></script>

--- a/progressUtils.js
+++ b/progressUtils.js
@@ -54,3 +54,5 @@ if (typeof window !== 'undefined') {
   window.savePRs = savePRs;
   window.updatePRs = updatePRs;
 }
+
+export { computeOneRepMax, loadPRs, savePRs, updatePRs };


### PR DESCRIPTION
## Summary
- allow progress utilities to be imported as an ES module
- load `progressUtils.js` using a module script in `index.html`
- add Babel config so Jest can parse ES module syntax

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b23180fb88323be316957c8890187