### PR TITLE
Fix ProgramTab syntax

### DIFF
--- a/ProgramTab.js
+++ b/ProgramTab.js
@@ -335,7 +335,7 @@ export default function ProgramTab() {
     }
   }, "Send"), /*#__PURE__*/React.createElement("button", {
     onClick: () => setShowShare(false)
-  }, "Cancel"));
+  }, "Cancel")));
 }
 const root = createRoot(document.getElementById('programTabReactRoot'));
 root.render(/*#__PURE__*/React.createElement(ProgramTab, null));


### PR DESCRIPTION
## Summary
- close parentheses correctly in ProgramTab

## Testing
- `npm test` *(fails: Cannot find module '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_685b264a5c188323bacc3a65dd5a1406