### PR TITLE
Add macro quick add widgets and mini charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -778,27 +778,52 @@
   </button>
 
   <!-- Main Macros Content -->
-  <div id="macrosMainContent" style="max-width: 600px; margin: 0 auto; text-align: center;">
-    <h2 style="font-size: 1.8rem; margin-bottom: 20px;">Targets</h2>
+  <div id="macrosMainContent" style="max-width: 600px; margin: 0 auto;">
+    <div id="targetsCard" class="card sticky">
+      <h2 style="font-size:1.5rem;">Targets <span id="offlineBadge" style="display:none;font-size:0.8rem;">🕒 Offline</span></h2>
+      <p style="font-size:1.1rem;">Energy: <span id="macroCalsProgress">0</span> / <span id="macroCalsTarget">0</span> kcal (<span id="macroCalsNet">0</span> net)</p>
+      <progress id="calsBar" value="0" max="100" style="width:100%;height:20px;margin-bottom:6px;"></progress>
+      <div class="quick-add"><input id="qaCals" type="number" value="100"><button onclick="quickAdd('cals')">+</button></div>
 
-    <p style="font-size: 1.3rem;">Energy: <span id="macroCalsProgress">0</span> / <span id="macroCalsTarget">0</span> kcal (<span id="macroCalsNet">0</span> net)</p>
-    <progress id="calsBar" value="0" max="100" style="width: 100%; height: 20px; margin-bottom: 20px;"></progress>
+      <p style="font-size:1rem;">Protein: <span id="macroProteinProgress">0</span> / <span id="macroProteinTarget">0</span> g</p>
+      <progress id="proteinBar" value="0" max="100" style="width:100%;height:15px;margin-bottom:6px;"></progress>
+      <div class="quick-add"><input id="qaProtein" type="number" value="10"><button onclick="quickAdd('protein')">+</button></div>
 
-    <p style="font-size: 1.2rem;">Protein: <span id="macroProteinProgress">0</span> / <span id="macroProteinTarget">0</span> g</p>
-    <progress id="proteinBar" value="0" max="100" style="width: 100%; height: 15px; margin-bottom: 20px;"></progress>
+      <p style="font-size:1rem;">Carbs: <span id="macroCarbsProgress">0</span> / <span id="macroCarbsTarget">0</span> g</p>
+      <progress id="carbBar" value="0" max="100" style="width:100%;height:15px;margin-bottom:6px;"></progress>
+      <div class="quick-add"><input id="qaCarbs" type="number" value="10"><button onclick="quickAdd('carbs')">+</button></div>
 
-    <p style="font-size: 1.2rem;">Carbs: <span id="macroCarbsProgress">0</span> / <span id="macroCarbsTarget">0</span> g</p>
-    <progress id="carbBar" value="0" max="100" style="width: 100%; height: 15px; margin-bottom: 20px;"></progress>
+      <p style="font-size:1rem;">Fat: <span id="macroFatProgress">0</span> / <span id="macroFatTarget">0</span> g</p>
+      <progress id="fatBar" value="0" max="100" style="width:100%;height:15px;margin-bottom:6px;"></progress>
+      <div class="quick-add"><input id="qaFat" type="number" value="5"><button onclick="quickAdd('fat')">+</button></div>
 
-    <p style="font-size: 1.2rem;">Fat: <span id="macroFatProgress">0</span> / <span id="macroFatTarget">0</span> g</p>
-    <progress id="fatBar" value="0" max="100" style="width: 100%; height: 15px; margin-bottom: 30px;"></progress>
+      <div id="sparkContainer" style="display:flex;justify-content:space-around;margin-top:8px;">
+        <canvas id="calSpark" width="120" height="40"></canvas>
+        <canvas id="proteinSpark" width="120" height="40"></canvas>
+      </div>
+    </div>
 
-    <div id="macroMealContainer"></div>
-    <button id="macroMeal" style="width: 100%; font-size: 1.1rem; padding: 12px;">➕ Add Meal</button>
-    <button onclick="scanBarcode()" style="width:100%;font-size:1rem;">📷 Scan Barcode</button>
-    <input id="recipeUrl" placeholder="Import recipe URL" style="width:100%;padding:6px;margin-top:10px;"/>
-    <button onclick="importRecipe(recipeUrl.value).then(r=>console.log(r))" style="width:100%;font-size:1rem;">Import Recipe</button>
-    <button id="adjustMacrosToggle" class="btn" onclick="toggleTargetForm()">
+    <div id="heatmap" class="heatmap"></div>
+
+    <details id="mealsCard" class="card" style="margin-top:10px;">
+      <summary>Meals <button onclick="scanBarcode()" class="icon-btn">📷</button></summary>
+      <div style="margin-top:10px;">
+        <div style="margin-bottom:10px;">
+          <select id="favSelect" onchange="logFavorite(this.value)">
+            <option value="">Favorites</option>
+          </select>
+        </div>
+        <div style="display:flex;margin-bottom:10px;">
+          <input id="recipeUrl" placeholder="Import recipe URL" style="flex:1;padding:6px;"/>
+          <button onclick="fetchRecipe()" style="margin-left:6px;">Fetch</button>
+        </div>
+        <div id="macroMealContainer"></div>
+      </div>
+    </details>
+
+    <button id="addMealFab" class="fab" onclick="addMacroMeal()">＋</button>
+
+    <button id="adjustMacrosToggle" class="btn" onclick="toggleTargetForm()" style="margin-top:20px;">
       ⚙️ Adjust Macros
     </button>
   </div>
@@ -1140,6 +1165,12 @@ function showTab(tabName) {
   requestAnimationFrame(() => {
     tab.classList.add('active');
   });
+
+  if(tabName === 'macroTab' && window.renderSparklines){
+    renderSparklines();
+    renderHeatmap();
+    updateOfflineBadge();
+  }
 }
 
 

--- a/macrosFeatures.js
+++ b/macrosFeatures.js
@@ -40,6 +40,99 @@ export async function importRecipe(url) {
   }
 }
 
+export function quickAdd(type, amountInputId) {
+  const id = amountInputId || `qa${type.charAt(0).toUpperCase()+type.slice(1)}`;
+  const amt = Number(document.getElementById(id)?.value || 0);
+  if (!amt) return;
+  const prog = JSON.parse(localStorage.getItem('dailyMacroProgress') || '{"protein":0,"carbs":0,"fats":0,"cals":0}');
+  if (type === 'protein') prog.protein += amt;
+  else if (type === 'carbs') prog.carbs += amt;
+  else if (type === 'fat') prog.fats += amt;
+  else if (type === 'cals') prog.cals = (prog.cals || 0) + amt;
+  localStorage.setItem('dailyMacroProgress', JSON.stringify(prog));
+  if (window.renderDailyMacroProgress) window.renderDailyMacroProgress();
+}
+
+export async function fetchRecipe() {
+  const url = document.getElementById('recipeUrl').value;
+  if (!url) return;
+  const data = await importRecipe(url);
+  if (data) {
+    quickAdd('protein', null); // triggers update later with manual amounts
+    const prog = JSON.parse(localStorage.getItem('dailyMacroProgress') || '{"protein":0,"carbs":0,"fats":0}');
+    prog.protein += data.protein || 0;
+    prog.carbs += data.carbs || 0;
+    prog.fats += data.fat || 0;
+    localStorage.setItem('dailyMacroProgress', JSON.stringify(prog));
+    if (window.renderDailyMacroProgress) window.renderDailyMacroProgress();
+  } else {
+    alert('Could not parse recipe');
+  }
+}
+
+export function logFavorite(meal) {
+  if (!meal) return;
+  const list = JSON.parse(localStorage.getItem('favMeals') || '[]');
+  const found = list.find(f => f.name===meal);
+  if (found) {
+    quickAdd('protein');
+  }
+}
+
+export function updateOfflineBadge() {
+  const badge = document.getElementById('offlineBadge');
+  if (badge) badge.style.display = navigator.onLine ? 'none' : 'inline-block';
+}
+
+export function renderSparklines() {
+  if (!window.Chart) return;
+  const key = `macroHistory_${window.currentUser || ''}`;
+  const history = JSON.parse(localStorage.getItem(key) || '[]').slice(-7);
+  const labels = history.map(h => h.date);
+  const cals = history.map(h => (h.totals.protein*4)+(h.totals.carbs*4)+(h.totals.fats*9));
+  const proteins = history.map(h => h.totals.protein);
+  const ctx1 = document.getElementById('calSpark').getContext('2d');
+  const ctx2 = document.getElementById('proteinSpark').getContext('2d');
+  if (window.calChart) window.calChart.destroy();
+  if (window.proChart) window.proChart.destroy();
+  window.calChart = new Chart(ctx1,{type:'line',data:{labels,datasets:[{data:cals,borderColor:'#2F80ED',fill:false}]},options:{plugins:{legend:{display:false}},scales:{x:{display:false},y:{display:false}}}});
+  window.proChart = new Chart(ctx2,{type:'line',data:{labels,datasets:[{data:proteins,borderColor:'#F2994A',fill:false}]},options:{plugins:{legend:{display:false}},scales:{x:{display:false},y:{display:false}}}});
+}
+
+export function renderHeatmap() {
+  const container = document.getElementById('heatmap');
+  if (!container) return;
+  container.innerHTML = '';
+  const key = `macroHistory_${window.currentUser || ''}`;
+  const history = JSON.parse(localStorage.getItem(key) || '[]');
+  const map = {};
+  history.forEach(h => {
+    const total = (h.totals.protein*4)+(h.totals.carbs*4)+(h.totals.fats*9);
+    const target = (JSON.parse(localStorage.getItem(`macroTargets_${window.currentUser}`))||{}).calories||1;
+    map[h.date] = Math.min(1,total/target);
+  });
+  for(let i=29;i>=0;i--){
+    const d = new Date();
+    d.setDate(d.getDate()-i);
+    const keyDate = d.toISOString().slice(0,10);
+    const pct = map[keyDate] || 0;
+    const cell = document.createElement('div');
+    const g = Math.floor(255*(1-pct));
+    const r = Math.floor(255*pct);
+    cell.style.background=`rgb(${r},${g},100)`;
+    cell.title=keyDate;
+    cell.addEventListener('click',()=>{
+      if(window.loadDay) window.loadDay(keyDate);
+    });
+    container.appendChild(cell);
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('online', updateOfflineBadge);
+  window.addEventListener('offline', updateOfflineBadge);
+}
+
 export function planWeek(meals) {
   const groceries = {};
   meals.forEach(day => {
@@ -66,4 +159,10 @@ if (typeof window !== 'undefined') {
   window.importRecipe = importRecipe;
   window.planWeek = planWeek;
   window.toggleTargetForm = toggleTargetForm;
+  window.quickAdd = quickAdd;
+  window.fetchRecipe = fetchRecipe;
+  window.logFavorite = logFavorite;
+  window.updateOfflineBadge = updateOfflineBadge;
+  window.renderSparklines = renderSparklines;
+  window.renderHeatmap = renderHeatmap;
 }

--- a/style.css
+++ b/style.css
@@ -4,3 +4,63 @@
   padding: 8px 16px;
   font-size: 1rem;
 }
+
+.card {
+  background: var(--card-bg);
+  padding: 12px;
+  margin-bottom: 10px;
+  box-shadow: var(--shadow);
+  border-radius: 6px;
+}
+
+.sticky {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.quick-add {
+  display:flex;
+  justify-content:flex-end;
+  margin-bottom:6px;
+}
+.quick-add input {
+  width:60px;
+  margin-right:4px;
+}
+
+.fab {
+  position: fixed;
+  bottom: 80px;
+  right: 20px;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: var(--primary);
+  color: var(--text-color);
+  font-size: 1.5rem;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  box-shadow: var(--shadow);
+  border:none;
+}
+
+.icon-btn {
+  border:none;
+  background:none;
+  font-size:1rem;
+}
+
+.heatmap {
+  display:grid;
+  grid-template-columns: repeat(15, 12px);
+  gap:2px;
+  justify-content:center;
+  margin-top:8px;
+}
+.heatmap div {
+  width:12px;
+  height:12px;
+  background:#eee;
+}


### PR DESCRIPTION
## Summary
- restructure macros tab to use sticky Targets card and Meals section
- add quick add inputs and floating add-meal button
- show offline status badge and heatmap
- implement Chart.js sparklines and helper functions

## Testing
- `npx jest` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685b36ab8f1c8323b764c1a9e8f4e7bc