### PR TITLE
Improve mobile UI layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -619,7 +619,7 @@
     <button data-target="calendarPanel">Calendar</button>
   </div>
   <div id="logPanel" class="panel active">
-  <h2>Resistance Exercise Log</h2>
+  <h2 class="tab-header">Resistance Exercise Log</h2>
 
 <div id="resistance-section">
   <div id="resistance-inputs">
@@ -707,7 +707,7 @@
       <button data-target="weightChartPanel">Chart</button>
     </div>
     <div id="weightLogPanel" class="panel active">
-    <h2>Bodyweight Tracker</h2>
+    <h2 class="tab-header">Bodyweight Tracker</h2>
     <input type="number" id="currentWeightInput" placeholder="Current Weight (kg)">
     <button onclick="addWeightEntry()">Add Weight</button>
     <input type="number" id="avgCalories" placeholder="Average Daily Calories" />
@@ -741,7 +741,7 @@
   </div>
   <div id="cfEntryPanel" class="panel active">
 
-  <h2>CrossFit Workout Tracker</h2>
+  <h2 class="tab-header">CrossFit Workout Tracker</h2>
 
   <input type="text" id="cfWorkoutName" placeholder="Workout Name (e.g., Murph)">
   <input type="number" id="cfMinutes" placeholder="Time (Minutes)">
@@ -776,7 +776,7 @@
     <button data-target="postsPanel">Posts</button>
   </div>
   <div id="groupsPanel" class="panel active">
-  <h2>Community</h2>
+  <h2 class="tab-header">Community</h2>
   <div>
     <input id="groupSearchInput" placeholder="Search groups">
     <input id="goalFilter" placeholder="Goal">
@@ -797,7 +797,7 @@
       <button data-target="cardioHistoryPanel">History</button>
     </div>
     <div id="cardioFormPanel" class="panel active">
-    <h2>Cardio Tracker</h2>
+    <h2 class="tab-header">Cardio Tracker</h2>
     <input type="text" id="cardioType" placeholder="Type (e.g. Running)">
     <input type="number" id="cardioDuration" placeholder="Duration (min)">
     <input type="number" id="cardioDistance" placeholder="Distance (km)">
@@ -942,7 +942,7 @@
       <button data-target="progressTogglePanel" class="active">Options</button>
       <button data-target="progressChartsPanel">Charts</button>
     </div>
-    <h2>Progress Overview</h2>
+    <h2 class="tab-header">Progress Overview</h2>
     <div class="progress-layout">
       <div id="progressTogglePanel" class="panel active">
       <nav class="progress-nav">
@@ -976,7 +976,7 @@
     <button data-target="historyWorkoutPanel" class="active">Workouts</button>
     <button data-target="historyMacroPanel">Macros</button>
   </div>
-  <h2>Log History</h2>
+  <h2 class="tab-header">Log History</h2>
   <div id="historyNav" style="margin-bottom:10px;">
     <button onclick="showHistoryMiniTab('workout')">Workout History</button>
     <button onclick="showHistoryMiniTab('macro')">Macro History</button>
@@ -3815,6 +3815,7 @@ function loadCrossfitTemplate() {
   renderMilestones();
   renderGoalBar();
   initMobilePanels();
+  placeMobileToggles();
 
 
 
@@ -3905,7 +3906,16 @@ window.exportCSV = exportCSV;
     });
   }
 
+  function placeMobileToggles() {
+    document.querySelectorAll('.tab-content').forEach(tab => {
+      const toggle = tab.querySelector('.mobile-panel-toggle');
+      const header = tab.querySelector('.tab-header') || tab.querySelector('h2');
+      if (toggle && header) header.appendChild(toggle);
+    });
+  }
+
   window.initMobilePanels = initMobilePanels;
+  window.placeMobileToggles = placeMobileToggles;
 
   function applyTheme(theme) {
     document.body.classList.remove('theme-dark', 'theme-neon', 'theme-light');

--- a/style.css
+++ b/style.css
@@ -68,9 +68,6 @@
 /* ——— MOBILE UI OVERRIDES ——— */
 @media (max-width: 768px) {
   /* Hide desktop sidebar & show a mobile nav toggle if you have one */
-  .side-menu {
-    display: none !important;
-  }
   .mobile-nav {
     display: flex !important;
   }
@@ -155,5 +152,38 @@
   }
   .tab-content .panel.active {
     display: block;
+  }
+}
+@media (max-width: 768px) {
+  .mobile-panel-toggle {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    z-index: 2000;
+    display: flex;
+    gap: 0.5rem;
+  }
+  .tab-header {
+    padding-top: 3rem;
+  }
+  .tab-content input,
+  .tab-content select,
+  .tab-content button {
+    min-width: 90%;
+    font-size: 1rem;
+    padding: 0.75rem 1rem;
+    margin: 0.5rem auto;
+    display: block;
+  }
+  .side-menu {
+    width: 100% !important;
+    left: -100%;
+    transition: left 0.3s ease;
+  }
+  .side-menu.open {
+    left: 0 !important;
+  }
+  .menu-toggle {
+    z-index: 2100;
   }
 }


### PR DESCRIPTION
## Summary
- tweak style.css for better mobile layout
- reposition mobile panel toggle elements in headers
- expose toggle placement helper and call it in DOM ready handler
- refine toggle placement function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c1fa5ff3483238fba812aeec88973