### PR TITLE
Fix undefined serverUrl breaking tab display

### DIFF
--- a/index.html
+++ b/index.html
@@ -1027,6 +1027,9 @@ let savedUser = localStorage.getItem("fitnessAppUser");
 let activeSection = null;
 let activeTab = null;
 
+// Base URL for backend API, populated from optional config.js
+let serverUrl = window.SERVER_URL || '';
+
 let airtableToken = '';
 let airtableBaseId = '';
 


### PR DESCRIPTION
## Summary
- tab switching broke due to a ReferenceError for `serverUrl`
- define `serverUrl` using `window.SERVER_URL` so config.js populates it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c2221b2b88323b4fb3b66a411a063