### PR TITLE
Refine mobile-only header behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -571,6 +571,11 @@
 
  
 <body>
+  <div class="mobile-header">
+    <button id="menuToggle" class="menu-toggle">☰</button>
+    <button class="mobile-panel-button" data-panel="log">Log</button>
+    <button class="mobile-panel-button" data-panel="calendar">Calendar</button>
+  </div>
 
 <div id="loginContainer" class="section active" style="max-width:400px;margin:40px auto;background:var(--card-bg);padding:20px;box-shadow:var(--shadow);border-radius:10px;color:#000;">
   <h2>Login to Pocket Coach</h2>
@@ -586,10 +591,7 @@
   <button onclick="openSection('pocketFinance')">PocketFinance</button>
 </div>
 
-<div id="pocketFitContainer" class="section" style="display:none;">
-  
-  <!-- Hamburger button -->
-  <button id="menuToggle" class="menu-toggle" aria-label="Toggle menu" aria-expanded="false">☰</button>
+<div id="pocketFitContainer" class="section app-container" style="display:none;">
 
   <!-- Sidebar -->
   <nav id="sideMenu" class="side-menu">
@@ -618,7 +620,7 @@
     <button data-target="logPanel" class="active">Log</button>
     <button data-target="calendarPanel">Calendar</button>
   </div>
-  <div id="logPanel" class="panel active">
+  <div id="logPanel" class="panel log-panel active">
   <h2 class="tab-header">Resistance Exercise Log</h2>
 
 <div id="resistance-section">
@@ -691,7 +693,7 @@
     <!-- Logs will render below this -->
     <div id="workoutsContainer" style="margin-top: 20px;"></div>
     </div>
-    <div id="calendarPanel" class="panel">
+    <div id="calendarPanel" class="panel calendar-panel">
       <div id="training-calendar" class="slide-up"></div>
     </div>
 
@@ -3817,6 +3819,16 @@ function loadCrossfitTemplate() {
   renderGoalBar();
   initMobilePanels();
   placeMobileToggles();
+
+  document.querySelectorAll('.mobile-panel-button').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      document
+        .querySelectorAll('.calendar-panel, .log-panel')
+        .forEach((p) => p.classList.remove('expanded'));
+      const which = `${btn.dataset.panel}-panel`;
+      document.querySelector(`.${which}`)?.classList.toggle('expanded');
+    });
+  });
 
 
 

--- a/style.css
+++ b/style.css
@@ -19,6 +19,11 @@
   z-index: 1;
 }
 
+/* Mobile header hidden on larger screens */
+.mobile-header {
+  display: none;
+}
+
 .quick-add {
   display:flex;
   justify-content:flex-end;
@@ -185,5 +190,65 @@
   }
   .menu-toggle {
     z-index: 2100;
+  }
+}
+/* MOBILE FIXES */
+@media (max-width: 768px) {
+  /* 1. Sidebar beneath controls */
+  .side-menu {
+    z-index: 1000;
+    width: 100vw;
+    left: 0;
+    transform: translateX(-100%);
+    transition: transform .3s ease;
+  }
+  .side-menu.open {
+    transform: translateX(0);
+  }
+
+  /* 2. Fixed mobile header for panel toggles + hamburger */
+  .mobile-header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3.5rem;
+    background: white;
+    display: flex;
+    align-items: center;
+    padding: 0 1rem;
+    z-index: 2000;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  }
+  .mobile-header .menu-toggle,
+  .mobile-header .mobile-panel-button {
+    margin-right: 0.5rem;
+  }
+
+  /* 3. Main content safe padding, pushed below header */
+  .tab-content,
+  .app-container {
+    padding: 4rem 1rem 1rem;
+  }
+
+  /* 4. Collapsed calendar panel */
+  .calendar-panel {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height .3s ease;
+  }
+  .calendar-panel.expanded {
+    max-height: 30rem;
+  }
+
+  /* 5. Bigger, tappable inputs */
+  .tab-content input,
+  .tab-content select,
+  .tab-content button {
+    display: block;
+    width: 100%;
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+    margin: 0.5rem 0;
   }
 }


### PR DESCRIPTION
## Summary
- hide the new `.mobile-header` by default
- show `.mobile-header` only on small screens and format toggle script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c24e375688323b6b9eda7263ed87f