### PR TITLE
Remove panel toggle from Training Log

### DIFF
--- a/index.html
+++ b/index.html
@@ -3889,6 +3889,8 @@ window.exportCSV = exportCSV;
 
   function initMobilePanels() {
     document.querySelectorAll('.mobile-panel-toggle').forEach(bar => {
+      const tab = bar.closest('.tab-content');
+      if (tab && tab.id === 'logTab') return; // disable panel toggles on Training Log
       bar.querySelectorAll('button').forEach(btn => {
         btn.addEventListener('click', () => {
           const target = btn.dataset.target;


### PR DESCRIPTION
## Summary
- skip `initMobilePanels` when the tab is `logTab`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dd934dc708323be31dde62120e31a