### PR TITLE
Fix text color for themes

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     body {
       font-family: 'Poppins', sans-serif;
       background-color: var(--bg-color);
-      color: #000;
+      color: var(--text-color);
       padding: 20px;
       margin: 0;
       width: 100vw;
@@ -114,7 +114,7 @@
       font-size: 14px;
       background: var(--card-bg);
       box-shadow: var(--shadow);
-      color: #000;
+      color: var(--text-color);
     }
     th, td {
       padding: 10px;
@@ -244,7 +244,7 @@
       box-shadow: var(--shadow);
       border-radius: 10px;
       margin-bottom: 20px;
-      color: #000;
+      color: var(--text-color);
       opacity: 0;
       transform: scale(0.9);
       transition: opacity 0.3s ease, transform 0.3s ease;
@@ -572,7 +572,7 @@
  
 <body>
 
-<div id="loginContainer" class="section active" style="max-width:400px;margin:40px auto;background:var(--card-bg);padding:20px;box-shadow:var(--shadow);border-radius:10px;color:#000;">
+<div id="loginContainer" class="section active" style="max-width:400px;margin:40px auto;background:var(--card-bg);padding:20px;box-shadow:var(--shadow);border-radius:10px;color:var(--text-color);">
   <h2>Login to Pocket Coach</h2>
   <input type="text" id="username" placeholder="Enter Username" />
   <input type="password" id="password" placeholder="Enter Password" />


### PR DESCRIPTION
## Summary
- apply theme text color to `body`
- use theme text color for tables and tab content
- ensure login container inherits the text color

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dde0701048323aae6705730934534