### PR TITLE
Fix missing closing div causing log tab not to render

### DIFF
--- a/index.html
+++ b/index.html
@@ -696,6 +696,7 @@
 
 
   </div>
+  </div>
 
   <div id="weightTab" class="tab-content">
     <div id="weightLogPanel" class="panel active">


### PR DESCRIPTION
## Summary
- close `logTab` section properly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861db2b34e4832397d7835de654495c