### PR TITLE
Add trainer mode settings panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -606,6 +606,7 @@
       <li><a href="#" data-target="progressTab">📈 Progress</a></li>
       <li><a href="#" data-target="logHistoryTab">📜 Log History</a></li>
       <li><button id="sidebarLogoutBtn" onclick="logout()">Logout</button></li>
+      <li class="coach-only"><a href="#" data-tab="settingsTab">⚙️ Settings</a></li>
     </ul>
   </nav>
 
@@ -956,6 +957,14 @@
       <div id="macroHistoryContainer"></div>
     </div>
   </div>
+</div>
+
+<div id="settingsTab" class="tab-content">
+  <h2>Settings</h2>
+  <label>
+    <input type="checkbox" id="trainerModeToggle" />
+    Enable Trainer Mode
+  </label>
 </div>
   </div>
 </div>
@@ -2773,6 +2782,25 @@ function closeMacroSettings() {
 // expose helpers for inline handlers
 window.openMacroSettings = openMacroSettings;
 window.closeMacroSettings = closeMacroSettings;
+
+function updateNavForTrainer(isTrainer) {
+  document.querySelectorAll('.coach-only').forEach(el => {
+    el.style.display = isTrainer ? 'block' : 'none';
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const saved = JSON.parse(localStorage.getItem('trainerMode') || 'false');
+  const toggle = document.getElementById('trainerModeToggle');
+  if (toggle) toggle.checked = saved;
+  updateNavForTrainer(saved);
+  if (toggle) {
+    toggle.addEventListener('change', e => {
+      localStorage.setItem('trainerMode', JSON.stringify(e.target.checked));
+      updateNavForTrainer(e.target.checked);
+    });
+  }
+});
 
 
   // Toggle FAB menu


### PR DESCRIPTION
## Summary
- add Coach-only Settings item to sidebar
- add Settings tab content with a Trainer Mode toggle
- show/hide coach-only items based on Trainer Mode preference

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68630cba002c8323bd4c4f671d21aa26