### PR TITLE
Make Settings tab visible by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -607,7 +607,7 @@
       <li><a href="#" data-target="logHistoryTab">📜 Log History</a></li>
       <li class="coach-only"><a href="#" data-tab="coachingTab">🏆 Coaching</a></li>
       <li><button id="sidebarLogoutBtn" onclick="logout()">Logout</button></li>
-      <li class="coach-only"><a href="#" data-tab="settingsTab">⚙️ Settings</a></li>
+      <li><a href="#" data-tab="settingsTab">⚙️ Settings</a></li>
     </ul>
   </nav>
 


### PR DESCRIPTION
## Summary
- show the Settings item in the sidebar even when trainer mode is off

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686551f9ee608323ae88b320bd5820af