### PR TITLE
Fix stray character in macros settings button

### DIFF
--- a/index.html
+++ b/index.html
@@ -795,7 +795,7 @@
 
 <div id="macroTab" class="tab-content" style="position: relative; padding: 20px;">
   <!-- Settings Button, top right, only shown on Macros tab -->
-<button id="macrosSettingsBtn" onclick="openMacroSettings()" style="position: absolute; top: 8px; right: 8px; display: none; font-size: 0.8rem; padding: 4px 8px;">>
+<button id="macrosSettingsBtn" onclick="openMacroSettings()" style="position: absolute; top: 8px; right: 8px; display: none; font-size: 0.8rem; padding: 4px 8px;">
     ⚙️ Settings
   </button>
 


### PR DESCRIPTION
## Summary
- clean up markup on macros settings button

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866b38dafac832380c1fcdc7e3fbe81