### PR TITLE
Remove duplicate setLoading function

### DIFF
--- a/index.html
+++ b/index.html
@@ -1173,17 +1173,6 @@ function setLoading(btn, state) {
   }
 }
 
-function setLoading(btn, state) {
-  if (!btn) return;
-  if (state) {
-    btn.classList.add('loading');
-    btn.disabled = true;
-  } else {
-    btn.classList.remove('loading');
-    btn.disabled = false;
-  }
-}
-
   
 // LOGIN
 async function startLogin() {


### PR DESCRIPTION
## Summary
- remove duplicate `setLoading` helper
- keep single `setLoading` call used by login and signup buttons

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866b38ec248832380422c4d2df7f4e8