### PR TITLE
Add credentials to all fetch calls

### DIFF
--- a/ProgramTab.js
+++ b/ProgramTab.js
@@ -123,6 +123,7 @@ export default function ProgramTab() {
     };
     const res = await fetch(`${window.SERVER_URL}/createProgram`, {
       method: 'POST',
+        credentials: "include",
       headers: {
         'Content-Type': 'application/json'
       },
@@ -142,6 +143,7 @@ export default function ProgramTab() {
   const doShare = async username => {
     if (!shareId) return;
     await fetch(`${window.SERVER_URL}/shareProgram`, {
+        credentials: "include",
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'

--- a/community.js
+++ b/community.js
@@ -20,6 +20,7 @@ async function createGroup(name, goal = '', tags = []) {
     try {
       const res = await fetch(`${window.SERVER_URL}/community/groups`, {
   method: 'POST',
+  credentials: 'include',
   headers: { 'Content-Type': 'application/json' },
   body: JSON.stringify({ name, creatorId: window.currentUser, goal, tags })
 });
@@ -46,7 +47,8 @@ async function fetchGroups(userId) {
   if (!userId || typeof fetch === 'undefined') return getGroups();
   try {
     const res = await fetch(`${window.SERVER_URL}/community/groups?userId=${encodeURIComponent(userId)}`, {
-      method: 'GET'
+      method: 'GET',
+      credentials: 'include'
     });
     if (res.ok) {
       groups = await res.json();
@@ -64,7 +66,7 @@ async function searchGroups(opts = {}) {
   if (opts.tag) params.set('tag', opts.tag);
   if (opts.search) params.set('search', opts.search);
   try {
-    const res = await fetch(`${window.SERVER_URL}/community/groups?${params.toString()}`, { method: 'GET' });
+    const res = await fetch(`${window.SERVER_URL}/community/groups?${params.toString()}`, { method: 'GET', credentials: 'include' });
     if (res.ok) {
       groups = await res.json();
       saveGroups();
@@ -87,7 +89,8 @@ function filterGroups(list, opts = {}) {
 async function fetchPosts(groupId) {
   try {
     const res = await fetch(`${window.SERVER_URL}/community/groups/${groupId}/posts`, {
-      method: 'GET'
+      method: 'GET',
+      credentials: 'include'
     });
     if (res.ok) {
       const posts = await res.json();
@@ -110,6 +113,7 @@ async function inviteUserToGroup(groupId, invitedUserId) {
   try {
     const res = await fetch(`${window.SERVER_URL}/community/groups/${groupId}/invite`, {
       method: 'POST',
+      credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ invitedUserId })
     });
@@ -137,6 +141,7 @@ async function shareProgramToGroup(groupId, programData) {
   try {
     const res = await fetch(`${window.SERVER_URL}/community/groups/${groupId}/share`, {
       method: 'POST',
+      credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ senderId: window.currentUser, programData })
     });
@@ -156,7 +161,8 @@ async function shareProgramToGroup(groupId, programData) {
 async function fetchProgress(groupId) {
   try {
     const res = await fetch(`${window.SERVER_URL}/community/groups/${groupId}/progress`, {
-      method: 'GET'
+      method: 'GET',
+      credentials: 'include'
     });
     if (res.ok) return await res.json();
   } catch (e) {
@@ -185,6 +191,7 @@ async function addPost(groupId, user, text) {
     try {
       await fetch(`${window.SERVER_URL}/community/groups/${groupId}/posts`, {
         method: 'POST',
+        credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ userId: user, text })
       });

--- a/index.html
+++ b/index.html
@@ -1061,7 +1061,7 @@ let airtableBaseId = '';
 
 async function fetchAirtableConfig() {
   try {
-    const res = await fetch(`${window.SERVER_URL}/config`);
+    const res = await fetch(`${window.SERVER_URL}/config`, { credentials: "include" });
     if (res.ok) {
       const cfg = await res.json();
       airtableToken = cfg.airtableToken;
@@ -1087,7 +1087,7 @@ async function fetchAirtableConfig() {
 
   if (window.SERVER_URL) {
     try {
-      const res = await fetch(`${window.SERVER_URL}/config`);
+      const res = await fetch(`${window.SERVER_URL}/config`, { credentials: "include" });
       if (res.ok) {
         const cfg = await res.json();
         airtableToken = cfg.airtableToken;
@@ -1190,6 +1190,7 @@ async function startLogin() {
   try {
     const response = await fetch(`${window.SERVER_URL}/login`, {
       method: 'POST',
+        credentials: "include",
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password })
     });
@@ -1302,6 +1303,7 @@ function showTab(tabName) {
 async function fetchUserMacroTargets(username) {
   const url = `https://api.airtable.com/v0/${airtableBaseId}/MacroTargets?filterByFormula={Username}='${username}'`;
   const response = await fetch(url, {
+      credentials: "include"
     headers: { Authorization: `Bearer ${airtableToken}` }
   });
   const data = await response.json();
@@ -1335,6 +1337,7 @@ async function startSignup() {
   try {
     const response = await fetch(`${window.SERVER_URL}/signup`, {
       method: 'POST',
+        credentials: "include",
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password })
     });
@@ -1695,6 +1698,7 @@ async function saveTemplate(username, templateName, templateData) {
   try {
     const response = await fetch(url, {
       method: 'POST',
+        credentials: "include",
       headers: {
         Authorization: `Bearer ${airtableToken}`,
         'Content-Type': 'application/json'
@@ -1723,6 +1727,7 @@ async function saveTemplate(username, templateName, templateData) {
 async function fetchTemplates(username) {
   const url = `https://api.airtable.com/v0/${airtableBaseId}/${templatesTableName}?filterByFormula={Username}='${username}'`;
   const response = await fetch(url, {
+    credentials: "include",
     headers: { Authorization: `Bearer ${airtableToken}` }
   });
   const data = await response.json();
@@ -1802,6 +1807,7 @@ async function sendTemplate() {
   try {
     const response = await fetch(`${window.SERVER_URL}/sendTemplate`, {
       method: 'POST',
+        credentials: "include",
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         fromUser: currentUser,
@@ -2027,7 +2033,7 @@ async function saveWorkoutToBackend(workout) {
     }
   };
   try {
-    await fetch(action.url, action.options);
+    await fetch(action.url, { ...action.options, credentials: "include" });
   } catch (err) {
     console.warn('offline - queueing workout', err);
     if (window.queueAction) queueAction(action);
@@ -2036,7 +2042,7 @@ async function saveWorkoutToBackend(workout) {
 
 async function loadWorkoutsFromBackend() {
   try {
-    const res = await fetch(`${window.SERVER_URL}/getWorkouts?username=${currentUser}`);
+    const res = await fetch(`${window.SERVER_URL}/getWorkouts?username=${currentUser}`, { credentials: "include" });
     const data = await res.json();
     if (data.workouts) {
       localStorage.setItem(`workouts_${currentUser}`, JSON.stringify(data.workouts));
@@ -2493,6 +2499,7 @@ async function saveToAirtable(username, target) {
   try {
     const r = await fetch(url, {
       method: "POST",
+        credentials: "include",
       headers: {
         Authorization: `Bearer ${airtableToken}`,
         "Content-Type": "application/json"
@@ -2715,6 +2722,7 @@ async function saveDailyMacroLog(username, date, meals, totals) {
   try {
     const response = await fetch(url, {
       method: "POST",
+        credentials: "include",
       headers: {
         Authorization: `Bearer ${airtableToken}`,
         "Content-Type": "application/json"
@@ -2754,6 +2762,7 @@ async function saveDailyMacroLog(username, date, meals, totals) {
   try {
     const response = await fetch(url, {
       method: "POST",
+        credentials: "include",
       headers: {
         Authorization: `Bearer ${airtableToken}`,
         "Content-Type": "application/json"
@@ -3574,6 +3583,7 @@ function showHistoryMiniTab(tab) {
 async function findUser(username) {
   const url = `https://api.airtable.com/v0/${airtableBaseId}/${usersTableName}?filterByFormula={Username}='${username}'`;
   const response = await fetch(url, {
+    credentials: "include",
     headers: { Authorization: `Bearer ${airtableToken}` }
   });
   const data = await response.json();
@@ -3584,6 +3594,7 @@ async function createUser(username, password) {
   const url = `https://api.airtable.com/v0/${airtableBaseId}/${usersTableName}`;
   await fetch(url, {
     method: 'POST',
+      credentials: "include",
     headers: {
       Authorization: `Bearer ${airtableToken}`,
       'Content-Type': 'application/json'
@@ -3599,6 +3610,7 @@ async function fetchDailyLogs(username) {
 
   try {
     const response = await fetch(url, {
+        credentials: "include",
       headers: { Authorization: `Bearer ${airtableToken}` }
     });
     const data = await response.json();

--- a/macrosFeatures.js
+++ b/macrosFeatures.js
@@ -24,7 +24,7 @@ export async function scanBarcode() {
 
 export async function importRecipe(url) {
   try {
-    const res = await fetch(url);
+    const res = await fetch(url, { credentials: "include" });
     const text = await res.text();
     const m = text.match(/(protein|fat|carb)s?\s*:?\s*(\d+)/gi);
     if (!m) return null;

--- a/offline.js
+++ b/offline.js
@@ -14,7 +14,7 @@ export async function processQueue() {
   for (let i = 0; i < pendingActions.length; i++) {
     const { url, options } = pendingActions[i];
     try {
-      await fetch(url, options);
+      await fetch(url, { ...options, credentials: "include" });
       pendingActions.splice(i, 1);
       i--;
     } catch (e) {


### PR DESCRIPTION
## Summary
- enable cookie usage by sending credentials with all fetch requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d46d6b480832395d56ffc8aa8224e