### PR TITLE
Fix syntax error for Airtable fetch

### DIFF
--- a/index.html
+++ b/index.html
@@ -1303,7 +1303,7 @@ function showTab(tabName) {
 async function fetchUserMacroTargets(username) {
   const url = `https://api.airtable.com/v0/${airtableBaseId}/MacroTargets?filterByFormula={Username}='${username}'`;
   const response = await fetch(url, {
-      credentials: "include"
+      credentials: "include",
     headers: { Authorization: `Bearer ${airtableToken}` }
   });
   const data = await response.json();


### PR DESCRIPTION
## Summary
- fix typo in `fetchUserMacroTargets` credentials object

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4eeb80e483239cf0f1dd360d27dc