### PR TITLE
Enable PWA support

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="ProgramTab.css">
   <link rel="stylesheet" href="style.css">
+  <link rel="manifest" href="/manifest.json">
   <style>
     /* Center all tab headers on the page */
     .tab-content > h2,
@@ -4063,6 +4064,15 @@ window.closeMacroSettings = closeMacroSettings;
     </script>
 
     <script type="module" src="ProgramTab.js"></script>
+
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () =>
+          navigator.serviceWorker.register('/service-worker.js')
+            .catch(err => console.error('SW failed:', err))
+        );
+      }
+    </script>
 
 
 </body>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "PocketFit",
+  "short_name": "PocketFit",
+  "start_url": "/index.html",
+  "display": "standalone",
+  "background_color": "#f9f9fb",
+  "theme_color": "#007bff",
+  "icons": [
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
+  ]
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,12 @@
+const CACHE_NAME = 'pocketfit-v1';
+const ASSETS = [
+  '/', '/index.html', '/styles.css', '/main.js',
+  '/icons/icon-192.png', '/icons/icon-512.png'
+];
+self.addEventListener('install', e =>
+  e.waitUntil(caches.open(CACHE_NAME).then(c => c.addAll(ASSETS)))
+);
+self.addEventListener('fetch', e =>
+  e.respondWith(caches.match(e.request).then(r => r || fetch(e.request)))
+);
+

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const dotenv = require('dotenv');
+const path = require('path');
 
 dotenv.config();
 
@@ -9,6 +10,7 @@ const PORT = process.env.PORT || 3000;
 app.use(cors());
 app.use(express.json());
 app.use(express.static(__dirname));
+app.use(express.static(path.join(__dirname, 'public')));
 
 const { calculateLeaderboard } = require('./community');
 


### PR DESCRIPTION
## Summary
- serve `/public` assets from Express
- add manifest link and SW registration to `index.html`
- create `public/manifest.json` and `service-worker.js`
- include placeholder icons directory

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed05d26e8832382b9d5b761e6330e