### PR TITLE
Enable PWA support

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="ProgramTab.css">
   <link rel="stylesheet" href="style.css">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#007bff">
   <style>
     /* Center all tab headers on the page */
     .tab-content > h2,
@@ -4063,7 +4065,6 @@ window.closeMacroSettings = closeMacroSettings;
     </script>
 
     <script type="module" src="ProgramTab.js"></script>
-
 
 </body>
 </html>

--- a/offline.js
+++ b/offline.js
@@ -29,3 +29,7 @@ if (typeof window !== 'undefined') {
   window.queueAction = queueAction;
   window.processQueue = processQueue;
 }
+
+if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/service-worker.js');
+}

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,13 @@
+{
+  "name": "PocketFit",
+  "short_name": "PocketFit",
+  "start_url": "/index.html",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#f9f9fb",
+  "theme_color": "#007bff",
+  "icons": [
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
+  ]
+}

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const dotenv = require('dotenv');
+const path = require('path');
 
 dotenv.config();
 
@@ -9,6 +10,16 @@ const PORT = process.env.PORT || 3000;
 app.use(cors());
 app.use(express.json());
 app.use(express.static(__dirname));
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.get('/manifest.webmanifest', (req, res) => {
+  res.type('application/manifest+json');
+  res.sendFile(path.join(__dirname, 'public', 'manifest.webmanifest'));
+});
+
+app.get('/service-worker.js', (req, res) => {
+  res.sendFile(path.join(__dirname, 'service-worker.js'));
+});
 
 const { calculateLeaderboard } = require('./community');
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,22 @@
+const CACHE_NAME = 'pocketfit-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/style.css',
+  '/manifest.webmanifest',
+  '/icons/icon-192.png',
+  '/icons/icon-512.png'
+];
+
+self.addEventListener('install', (e) => {
+  e.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('fetch', (e) => {
+  e.respondWith(
+    caches.match(e.request).then((res) => res || fetch(e.request))
+  );
+});
+


### PR DESCRIPTION
## Summary
- serve manifest and service worker from Express
- add manifest link and theme color meta
- create `public/manifest.webmanifest`
- register service worker in `offline.js`
- move service worker to project root

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed05d26e8832382b9d5b761e6330e